### PR TITLE
Fix malformed lambda proxy response with empty headers

### DIFF
--- a/src/Http/LambdaResponse.php
+++ b/src/Http/LambdaResponse.php
@@ -67,12 +67,16 @@ class LambdaResponse
 
     public function toJson() : string
     {
+        // The headers must be a JSON object. If the PHP array is empty it is
+        // serialized to `[]` (we want `{}`) so we force it to an empty object.
+        $headers = empty($this->headers) ? new \stdClass : $this->headers;
+
         // This is the format required by the AWS_PROXY lambda integration
         // See https://stackoverflow.com/questions/43708017/aws-lambda-api-gateway-error-malformed-lambda-proxy-response
         return json_encode([
             'isBase64Encoded' => false,
             'statusCode' => $this->statusCode,
-            'headers' => $this->headers,
+            'headers' => $headers,
             'body' => $this->body,
         ]);
     }

--- a/tests/Http/LambdaResponseTest.php
+++ b/tests/Http/LambdaResponseTest.php
@@ -63,6 +63,17 @@ class LambdaResponseTest extends TestCase
         ]);
     }
 
+    /**
+     * @test
+     */
+    public function test empty headers are considered objects()
+    {
+        $response = LambdaResponse::fromPsr7Response(new EmptyResponse);
+
+        // Make sure that the headers are `"headers":{}` (object) and not `"headers":[]` (array)
+        self::assertEquals('{"isBase64Encoded":false,"statusCode":204,"headers":{},"body":""}', $response->toJson());
+    }
+
     private function assertJsonPayload(LambdaResponse $response, array $expected)
     {
         self::assertEquals($expected, json_decode($response->toJson(), true));


### PR DESCRIPTION
The headers must be a JSON object. If the PHP array is empty it is serialized to `[]` (we want `{}`), so we force it to an empty object.