### PR TITLE
Enable opcache and use it with the file cache

### DIFF
--- a/bin/php/Dockerfile
+++ b/bin/php/Dockerfile
@@ -38,6 +38,8 @@ RUN ./configure \
     # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
     --enable-mbstring \
     --enable-mysqlnd \
+    # Allows to use the opcache.file_cache option
+    --enable-opcache-file \
     --enable-soap \
     --enable-zip \
     --with-curl \

--- a/bin/php/Dockerfile
+++ b/bin/php/Dockerfile
@@ -38,6 +38,7 @@ RUN ./configure \
     # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
     --enable-mbstring \
     --enable-mysqlnd \
+    --enable-opcache \
     # Allows to use the opcache.file_cache option
     --enable-opcache-file \
     --enable-soap \
@@ -48,7 +49,8 @@ RUN ./configure \
     --with-gd \
     --with-pdo-mysql \
     # https://github.com/docker-library/php/issues/439
-    --with-mhash \
-    --without-pear
+    --with-mhash
 
 RUN make -j 5
+
+RUN make install

--- a/bin/php/build.sh
+++ b/bin/php/build.sh
@@ -21,9 +21,15 @@ docker build --build-arg PHP_VERSION=$PHP_VERSION_GIT_BRANCH -t php-build .
 container=$(docker create php-build)
 
 docker -D cp $container:/php-src-$PHP_VERSION_GIT_BRANCH/sapi/cli/php .
+mkdir -p ext
+docker -D cp $container:/usr/local/lib/php/extensions/no-debug-non-zts-20170718/opcache.a ext/opcache.a
+docker -D cp $container:/usr/local/lib/php/extensions/no-debug-non-zts-20170718/opcache.so ext/opcache.so
 docker rm $container
 
-tar czf $PHP_VERSION_GIT_BRANCH.tar.gz php
+tar czf $PHP_VERSION_GIT_BRANCH.tar.gz php ext
 rm php
+rm ext/opcache.a
+rm ext/opcache.so
+rmdir ext
 aws s3 cp $PHP_VERSION_GIT_BRANCH.tar.gz s3://bref-php/bin/ --acl public-read
 rm $PHP_VERSION_GIT_BRANCH.tar.gz

--- a/bref.php
+++ b/bref.php
@@ -29,6 +29,13 @@ $silly = new Application;
 $silly->command('hello [name]', function (string $name = 'World!', OutputInterface $output) {
     $output->writeln('Hello ' . $name);
 });
+$silly->command('phpinfo', function (OutputInterface $output) {
+    ob_start();
+    phpinfo();
+    $phpinfo = ob_get_contents();
+    ob_clean();
+    $output->write($phpinfo);
+});
 
 $app = new \Bref\Application;
 $app->simpleHandler(function (array $event) {

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -164,6 +164,8 @@ class Deployer
             ->mustRun();
         // Set correct permissions on the file
         $this->fs->chmod('.bref/output/.bref/bin', 0755);
+        // Install our custom php.ini
+        $this->fs->copy(__DIR__ . '/../../template/php.ini', '.bref/output/.bref/php.ini');
         $progress->advance();
 
         $progress->setMessage('Installing `handler.js`');

--- a/template/handler.js
+++ b/template/handler.js
@@ -15,8 +15,13 @@ exports.handle = function(event, context, callback) {
         fs.mkdirSync(TMP_DIRECTORY);
     }
 
+    // Ensure the directory for storing the opcache file exists else PHP crashes
+    if (!fs.existsSync(TMP_DIRECTORY + '/opcache')) {
+        fs.mkdirSync(TMP_DIRECTORY + '/opcache');
+    }
+
     // Execute bref.php and pass it the event as argument
-    let script = spawn('php', [PHP_FILE, JSON.stringify(event)]);
+    let script = spawn('php', ['--php-ini=.bref/php.ini', PHP_FILE, JSON.stringify(event)]);
 
     // PHP's output is passed to the lambda's logs
     script.stdout.on('data', function(data) {

--- a/template/php.ini
+++ b/template/php.ini
@@ -16,3 +16,6 @@ opcache.validate_timestamps=0
 # See https://tideways.com/profiler/blog/fine-tune-your-opcache-configuration-to-avoid-caching-suprises
 opcache.memory_consumption=128
 opcache.max_accelerated_files=10000
+
+extension_dir=/var/task/.bref/bin/ext
+zend_extension=opcache.so

--- a/template/php.ini
+++ b/template/php.ini
@@ -1,0 +1,18 @@
+opcache.enable=1
+opcache.enable_cli=1
+
+# Store the opcodes into a file cache instead of memory
+# Since PHP runs on lambdas with a new process each time the memory cache is lost
+opcache.file_cache="/tmp/.bref/opcache"
+# Disable the memory cache since it's useless
+opcache.file_cache_only=1
+# Skip this check to save a it
+opcache.validate_permission=0
+
+# The code is readonly on lambdas so it never changes
+opcache.validate_timestamps=0
+
+# Set sane values, modern PHP applications have higher needs than opcache's defaults
+# See https://tideways.com/profiler/blog/fine-tune-your-opcache-configuration-to-avoid-caching-suprises
+opcache.memory_consumption=128
+opcache.max_accelerated_files=10000

--- a/template/php.ini
+++ b/template/php.ini
@@ -5,6 +5,7 @@ opcache.enable_cli=1
 # Since PHP runs on lambdas with a new process each time the memory cache is lost
 opcache.file_cache="/tmp/.bref/opcache"
 # Disable the memory cache since it's useless
+# In my tests it allows to gain 30% of response time in a classic API controller
 opcache.file_cache_only=1
 # Skip this check to save a it
 opcache.validate_permission=0


### PR DESCRIPTION
Opcache usually works in memory, compiling PHP code to opcode and caching it in memory between HTTP requests. Since on lambdas the PHP process is terminated between requests, the classic behavior of opcache doesn't work (the cache is cleared every time).

To make opcache work we enable its "file cache" mode where opcache writes the opcode into a file (with the `opcache.file_cache` option). When the PHP process starts, it reads the opcodes from the file cache.