### PR TITLE
Auto-deploy Bref internal files

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -9,9 +9,7 @@ package:
     - '*'
     - '**'
   include:
-    - handler.js
     - bref.php
-    - '.bref/**'
     - 'src/**'
     - 'vendor/**'
 

--- a/template/serverless.yml
+++ b/template/serverless.yml
@@ -9,9 +9,7 @@ package:
     - '*'
     - '**'
   include:
-    - handler.js
     - bref.php
-    - '.bref/**'
     - 'src/**'
     - 'vendor/**'
 


### PR DESCRIPTION
Users do not have to add Bref internal files to `serverless.yml` anymore. Instead those are added automatically, which makes it easier to get started and hides the details away.

This is also more future-proof if we ever decide to change how things work internally.

Users can remove the `handler.js` and `'.bref/**'` files from their `include` section in `serverless.yml`, however this is not mandatory.