### PR TITLE
Stream the output of serverless in `bref deploy`

### DIFF
--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -67,7 +67,15 @@ class Deployer
 
         $progress->setMessage('Uploading the lambda');
         $progress->display();
-        $this->runLocally('serverless deploy');
+        $process = new Process('serverless deploy', '.bref/output');
+        $process->setTimeout(null);
+        $completeDeployOutput = '';
+        $process->mustRun(function ($type, $buffer) use ($io, $progress, &$completeDeployOutput) {
+            $completeDeployOutput .= $buffer;
+            $progress->clear();
+            $io->writeln($buffer);
+            $progress->display();
+        });
 
         $progress->setMessage('Deployment success');
         $progress->finish();
@@ -210,12 +218,13 @@ class Deployer
      */
     private function createProgressBar(SymfonyStyle $io, int $max) : ProgressBar
     {
-        ProgressBar::setFormatDefinition('bref', "<comment>%message%</comment>\n %current%/%max% [%bar%] %elapsed:6s%\n");
+        ProgressBar::setFormatDefinition('bref', "<comment>%message%</comment>\n %current%/%max% [%bar%] %elapsed:6s%");
 
         $progressBar = $io->createProgressBar($max);
         $progressBar->setFormat('bref');
         $progressBar->setBarCharacter('░');
         $progressBar->setEmptyBarCharacter(' ');
+        $progressBar->setMessage('');
 
         $progressBar->start();
 


### PR DESCRIPTION
The goal is to show progress and more details. Also serverless includes the URL of the function when it's done, it's great to be able to click on it immediately.

The new output looks like this:

![2018-06-09 21 09 02](https://user-images.githubusercontent.com/720328/41195246-c3e3dbb6-6c29-11e8-9d68-44a679061990.gif)
