### PR TITLE
Simplify how to invoke lambdas locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ $payload = json_decode($result->get('Payload')->getContents(), true);
 Bref provides a helper to invoke the lambda locally, on your machine instead of the serverless provider:
 
 ```shell
-$ vendor/bin/bref local
+$ php bref.php bref:invoke
+
+# If you want to pass event data:
+$ php bref.php bref:invoke --event='{"name":"foo"}'
 ```
 
 ## Deletion
@@ -202,11 +205,19 @@ Hello Bob
 
 As you can see, all arguments and options after `bref cli --` are forwarded to the CLI command running on lambda.
 
-To test your CLI commands locally, simply run:
+To test your CLI commands locally (on your machine), simply run:
 
 ```shell
 $ php bref.php <commands and options>
 ```
+
+As you may have seen above, there is a special command that is automatically added to your CLI application:
+
+```shell
+$ php bref.php bref:invoke
+```
+
+That special command lets you invoke the `simpleHandler` on your development machine.
 
 ## Build hooks
 

--- a/bref
+++ b/bref
@@ -49,6 +49,9 @@ $app->command('init', function (SymfonyStyle $io) {
     ]);
 });
 
+/**
+ * @deprecated This command is deprecated in favor of running `php bref.php bref:invoke`
+ */
 $app->command(
     'local [-f|--function=] [-d|--data=] [-p|--path=] [--raw]',
     function (string $function, ?string $data, bool $raw, SymfonyStyle $io) {
@@ -57,7 +60,7 @@ $app->command(
     ->defaults([
         'function' => 'main',
     ])
-    ->descriptions('Invoke the lambda locally. To pass data to the lambda use the `--data` argument.', [
+    ->descriptions('**DEPRECATED** Invoke the lambda locally. To pass data to the lambda use the `--data` argument.', [
         '--function' => 'The name of the function in your service that you want to invoke. In Bref, by default, there is only the `main` function.',
         '--data' => 'String data to be passed as an event to your function. You can provide JSON data here.',
         '--raw' => 'Pass data as a raw string even if it is JSON. If not set, JSON data are parsed and passed as an object.',

--- a/src/Application.php
+++ b/src/Application.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Bref;
 
 use Bref\Bridge\Psr7\RequestFactory;
+use Bref\Cli\InvokeCommand;
 use Bref\Cli\WelcomeApplication;
 use Bref\Http\LambdaResponse;
 use Bref\Http\WelcomeHandler;
@@ -89,6 +90,11 @@ class Application
         $console->setAutoExit(false);
 
         $this->cliHandler = $console;
+
+        // Always add our `bref:invoke` command to test the lambda locally
+        $this->cliHandler->add(new InvokeCommand(function () {
+            return $this->simpleHandler;
+        }));
     }
 
     /**

--- a/src/Cli/InvokeCommand.php
+++ b/src/Cli/InvokeCommand.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Bref\Cli;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * A Symfony Console command to invoke a lambda locally.
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class InvokeCommand extends Command
+{
+    /**
+     * @var callable
+     */
+    private $invokerLocator;
+
+    public function __construct(callable $invokerLocator)
+    {
+        $this->invokerLocator = $invokerLocator;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('bref:invoke')
+            ->setDescription('Invoke the lambda locally when testing it in a development environment.')
+            ->setHelp('This command does NOT run the lambda on a serverless provider. It can be used to test the lambda in a "direct invocation" mode on a development machine.')
+            ->addOption('event', 'e', InputOption::VALUE_REQUIRED, 'Event data as JSON')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $simpleHandler = ($this->invokerLocator)();
+
+        $event = [];
+        if ($input->getOption('event')) {
+            $event = json_decode($input->getOption('event'), true);
+            if ($event === null) {
+                throw new \RuntimeException('The `--event` option provided contains invalid JSON: ' . $input->getOption('event'));
+            }
+        }
+
+        $payload = $simpleHandler($event);
+
+        $output->writeln(json_encode($payload, JSON_PRETTY_PRINT));
+    }
+}

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -25,6 +25,8 @@ class Deployer
 
     /**
      * Invoke the function and return the output.
+     *
+     * @deprecated in favor of `php bref.php bref:invoke`, will be removed.
      */
     public function invoke(SymfonyStyle $io, string $function, ?string $data, bool $raw) : string
     {


### PR DESCRIPTION
This follows https://github.com/mnapoli/bref/issues/17#issuecomment-396575392 (ping @t-geindre)

### Before

Test a basic lambda locally (`simpleHandler`):

```shell
vendor/bin/bref local
# This will generate the lambda locally in a separate directory, it will NOT use the dev setup
```

Test a CLI command locally (`cliHandler`):

```shell
php bref.php <my-command>
# This will NOT generate the lambda, instead the dev setup is used
```

Test a HTTP application locally (`httpHandler`):

```shell
php -S 127.0.0.1 bref.php
# This will NOT generate the lambda, instead the dev setup is used
```

### After

Test a basic lambda locally (`simpleHandler`):

```shell
php bref.php bref:invoke
# This will NOT generate the lambda, instead the dev setup is used
```

**(unchanged)** Test a CLI command locally (`cliHandler`):

```shell
php bref.php <my-command>
# This will NOT generate the lambda, instead the dev setup is used
```

**(unchanged)** Test a HTTP application locally (`httpHandler`):

```shell
php -S 127.0.0.1 bref.php
# This will NOT generate the lambda, instead the dev setup is used
```

### Summary of the changes

Bref now auto-adds a `bref:invoke` command in the CLI handler. This command can be invoked locally to test the lambda's `simpleHandler`.

Advantages:

- much much faster (the lambda is not generated like it was going to be deployed)
- uses the development environment, like the other methods
- more consistent: all helpers for testing the lambda involve invoking `bref.php` directly