### PR TITLE
Allow PHP version config

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,15 @@ hooks:
         - 'npm install'
 ```
 
+## PHP binary
+
+If you need a specific PHP version, you can define it in a `.bref.yml` file:
+
+```yaml
+php:
+    version: 7.2.6
+``` 
+
 ## Contributing
 
 There are a lot of detailed `TODO` notes in the codebase. Feel free to work on these.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,11 @@ php:
     version: 7.2.6
 ``` 
 
+Here is the list of versions available:
+
+- 7.2.5
+- 7.2.2
+
 ## Contributing
 
 There are a lot of detailed `TODO` notes in the codebase. Feel free to work on these.

--- a/bref
+++ b/bref
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
-const PHP_TARGET_VERSION = '7.2.5';
+const DEFAULT_PHP_TARGET_VERSION = '7.2.5';
 
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -136,7 +136,7 @@ class Deployer
             /*
              * TODO This option allows to customize the PHP binary used. It should be documented
              * and probably moved to a dedicated option like:
-             * php:	
+             * php:
              *     url: 'https://s3.amazonaws.com/...'
              */
             $defaultUrl = 'https://s3.amazonaws.com/bref-php/bin/php-' . $phpVersion . '.tar.gz';

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -127,26 +127,15 @@ class Deployer
 
         // Cache PHP's binary in `.bref/bin/php` to avoid downloading it
         // on every deploy.
-        /*
-         * TODO Allow choosing a PHP version instead of using directly the
-         * constant `PHP_TARGET_VERSION`. That could be done using the `.bref.yml`
-         * config file: there could be an option in that config, for example:
-         * php:
-         *     version: 7.2.2
-         */
+        $phpVersion = $projectConfig['php']['version'] ?? DEFAULT_PHP_TARGET_VERSION;
+
         $progress->setMessage('Downloading PHP in the `.bref/bin/` directory');
         $progress->display();
-        if (!$this->fs->exists('.bref/bin/php/php-' . PHP_TARGET_VERSION . '.tar.gz')) {
+        if (!$this->fs->exists('.bref/bin/php/php-' . $phpVersion . '.tar.gz')) {
             $this->fs->mkdir('.bref/bin/php');
-            $defaultUrl = 'https://s3.amazonaws.com/bref-php/bin/php-' . PHP_TARGET_VERSION . '.tar.gz';
-            /*
-             * TODO This option allows to customize the PHP binary used. It should be documented
-             * and probably moved to a dedicated option like:
-             * php:
-             *     url: 'https://s3.amazonaws.com/...'
-             */
-            $url = $projectConfig['php'] ?? $defaultUrl;
-            (new Process("curl -sSL $url -o .bref/bin/php/php-" . PHP_TARGET_VERSION . ".tar.gz"))
+            $defaultUrl = 'https://s3.amazonaws.com/bref-php/bin/php-' . $phpVersion . '.tar.gz';
+            $url = $projectConfig['php']['url'] ?? $defaultUrl;
+            (new Process("curl -sSL $url -o .bref/bin/php/php-" . $phpVersion . ".tar.gz"))
                 ->setTimeout(null)
                 ->mustRun();
         }
@@ -155,7 +144,7 @@ class Deployer
         $progress->setMessage('Installing the PHP binary');
         $progress->display();
         $this->fs->mkdir('.bref/output/.bref/bin');
-        (new Process('tar -xzf .bref/bin/php/php-' . PHP_TARGET_VERSION . '.tar.gz -C .bref/output/.bref/bin'))
+        (new Process('tar -xzf .bref/bin/php/php-' . $phpVersion . '.tar.gz -C .bref/output/.bref/bin'))
             ->mustRun();
         // Set correct permissions on the file
         $this->fs->chmod('.bref/output/.bref/bin', 0755);

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -133,6 +133,9 @@ class Deployer
         $progress->display();
         if (!$this->fs->exists('.bref/bin/php/php-' . $phpVersion . '.tar.gz')) {
             $this->fs->mkdir('.bref/bin/php');
+            /*
+             * TODO This option allows to customize the PHP binary used. It should be documented
+             */
             $defaultUrl = 'https://s3.amazonaws.com/bref-php/bin/php-' . $phpVersion . '.tar.gz';
             $url = $projectConfig['php']['url'] ?? $defaultUrl;
             (new Process("curl -sSL $url -o .bref/bin/php/php-" . $phpVersion . ".tar.gz"))

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -135,6 +135,9 @@ class Deployer
             $this->fs->mkdir('.bref/bin/php');
             /*
              * TODO This option allows to customize the PHP binary used. It should be documented
+             * and probably moved to a dedicated option like:
+             * php:	
+             *     url: 'https://s3.amazonaws.com/...'
              */
             $defaultUrl = 'https://s3.amazonaws.com/bref-php/bin/php-' . $phpVersion . '.tar.gz';
             $url = $projectConfig['php']['url'] ?? $defaultUrl;


### PR DESCRIPTION
We will soon need to define a PHP version in our projects. So I made this PR after seeing some todos in the code.

I didn't mention the `php/url` configuration in the README for now, I think it would require more information on how to build the php archive (php binary, ext directory with opcache extension).

As it changes a bit the php config, this introduces a BC break.

Also, it could be useful to provide a list of php versions available.