### PR TITLE
Allow PHP archive to provide a php.ini file

### DIFF
--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -159,8 +159,13 @@ class Deployer
             ->mustRun();
         // Set correct permissions on the file
         $this->fs->chmod('.bref/output/.bref/bin', 0755);
-        // Install our custom php.ini
-        $this->fs->copy(__DIR__ . '/../../template/php.ini', '.bref/output/.bref/php.ini');
+        // Check if binary package provides a php.ini
+        $phpIniFile = __DIR__ . '/../../template/php.ini';
+        if ($this->fs->exists($providedPhpIniFile = '.bref/output/.bref/bin/php.ini')) {
+            $phpIniFile = $providedPhpIniFile;
+        }
+        // Install custom php.ini
+        $this->fs->copy($phpIniFile, '.bref/output/.bref/php.ini');
         $progress->advance();
 
         $progress->setMessage('Installing Bref files for NodeJS');


### PR DESCRIPTION
Bref allow us to provide an archive containing our version of PHP, that's why I think we should also be able to provide the related php.ini file.

Bref install a default php.ini file containing opcahe configuration but there is no guaranty that related extensions will be available in the archive.

Just to keep bref working with existing archives, I left the default php.ini as a fallback if there's no php.ini file in the archive.

As mentioned in #26, this would allow us to embed more extensions in the archive and load them.

fix #26 