### PR TITLE
Add INTL extension

### DIFF
--- a/bin/php/Dockerfile
+++ b/bin/php/Dockerfile
@@ -20,7 +20,12 @@ RUN yum --releasever=2017.03 install \
     curl-devel \
     # The pecl command uses find
     findutils \
-    php-pear -y > /dev/null
+    php-pear \
+    # C++ & ICU are required by INTL
+    libicu \
+    libicu-devel \
+    c++ \
+    gcc-c++ -y > /dev/null
 
 RUN curl -sL https://github.com/php/php-src/archive/$PHP_VERSION.tar.gz | tar -zxv
 
@@ -46,6 +51,7 @@ RUN ./configure \
     --enable-opcache-file \
     --enable-soap \
     --enable-zip \
+    --enable-intl \
     --with-curl \
     --with-openssl \
     --with-zlib \

--- a/bin/php/build.sh
+++ b/bin/php/build.sh
@@ -31,12 +31,19 @@ docker -D cp $container:/php-src-php-$PHP_VERSION/sapi/cli/php .
 mkdir -p ext
 docker -D cp $container:/usr/local/lib/php/extensions/no-debug-non-zts-20170718/. ext/
 
+# Fetch ICU libraries required by INTL extension
+mkdir -p lib
+docker -D cp $container:/usr/lib64/libicui18n.so.50.1.2 lib/libicui18n.so.50
+docker -D cp $container:/usr/lib64/libicuuc.so.50.1.2 lib/libicuuc.so.50
+docker -D cp $container:/usr/lib64/libicudata.so.50.1.2 lib/libicudata.so.50
+docker -D cp $container:/usr/lib64/libicuio.so.50.1.2 lib/libicuio.so.50
+
 docker rm $container
 
 # Put all that in an archive
-tar czf php-$PHP_VERSION.tar.gz php ext
+tar czf php-$PHP_VERSION.tar.gz php ext lib
 rm php
-rm -rf ext
+rm -rf ext lib
 
 # Upload the archive to AWS S3
 aws s3 cp php-$PHP_VERSION.tar.gz s3://bref-php/bin/ --acl public-read

--- a/template/handler.js
+++ b/template/handler.js
@@ -1,6 +1,11 @@
 if (process.env['LAMBDA_TASK_ROOT']) {
+    // add bin directory to PATH to run PHP binary
     process.env['PATH'] = process.env['PATH']
-        + ':' + process.env['LAMBDA_TASK_ROOT'] + '/.bref/bin'; // for PHP
+        + ':' + process.env['LAMBDA_TASK_ROOT'] + '/.bref/bin';
+
+    // add lib directory to LD_LIBRARY_PATH to make PHP binary able to load required libraries
+    process.env['LD_LIBRARY_PATH'] = process.env['LD_LIBRARY_PATH']
+        + ':' + process.env['LAMBDA_TASK_ROOT'] + '/.bref/bin/lib';
 }
 
 const spawn = require('child_process').spawn;


### PR DESCRIPTION
This PR isn't meant to be merged yet, but just to open a discussion.

Adding the INTL extension to PHP makes it to depend on ICU libraries. So I added a `lib` directory to the tar archive where the ICU's library files are stored. Then, in `handler.js`, I added this `lib` directory to `LD_LIBRARY_PATH`. This is working fine.

The issue here, IMO, is that it adds 4 files for about 25MB extra load:
```bash
$ du libicu* -h 
20M     libicudata.so.50
2,0M    libicui18n.so.50
52K     libicuio.so.50
1,5M    libicuuc.so.50
```

@mnapoli what do you think?

This extension can be replaced by [symfony/polyfill-intl-icu](https://github.com/symfony/polyfill-intl-icu) and [symfony/polyfill-intl-normalizer](https://github.com/symfony/polyfill-intl-normalizer) but not all classes and functions are provided by those packages (eg [Transliterator](http://php.net/transliterator)).