### PR TITLE
Add INTL extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,16 +252,17 @@ You can also define `php.ini` configuration flags and activate extensions:
 ```yaml
 php:
     configuration:
-        max_execution_time: 300
+        memory_limit: 256M
     extensions:
         - redis
 ```
 
 Here is the list of extensions available:
 
-- Redis: `redis`
+- Intl: `intl`
 - MongoDB: `mongodb`
 - New Relic: `newrelic`
+- Redis: `redis`
 
 ## Contributing
 

--- a/bin/php/Dockerfile
+++ b/bin/php/Dockerfile
@@ -20,7 +20,12 @@ RUN yum --releasever=2017.03 install \
     curl-devel \
     # The pecl command uses find
     findutils \
-    php-pear -y > /dev/null
+    php-pear \
+    # C++ & ICU are required by INTL
+    libicu \
+    libicu-devel \
+    c++ \
+    gcc-c++ -y > /dev/null
 
 RUN curl -sL https://github.com/php/php-src/archive/$PHP_VERSION.tar.gz | tar -zxv
 
@@ -60,9 +65,22 @@ RUN make install > /dev/null
 
 RUN pecl install mongodb redis > /dev/null
 
-WORKDIR /
+# INTL compilation
+
+WORKDIR /php-src-$PHP_VERSION/ext/intl
+
+RUN phpize
+
+RUN ./configure
+
+RUN make
+
+RUN make install
 
 # Install newrelic extension, not available in pecl
+
+WORKDIR /
+
 RUN NEWRELIC_VERSION="$(curl -sS https://download.newrelic.com/php_agent/release/ | sed -n 's/.*>\(.*linux\).tar.gz<.*/\1/p')" \
    && curl -sS "https://download.newrelic.com/php_agent/release/${NEWRELIC_VERSION}.tar.gz" | gzip -dc | tar xf - \
    && cd "${NEWRELIC_VERSION}" \

--- a/bin/php/build.sh
+++ b/bin/php/build.sh
@@ -33,6 +33,7 @@ docker -D cp $container:/usr/local/lib/php/extensions/no-debug-non-zts-20170718/
 
 # Fetch ICU libraries required by INTL extension
 mkdir -p lib
+# libicui18n.so.50 exists as a symlink pointing to libicui18n.so.50.1.2, the same apply for all ICU's libraries
 docker -D cp $container:/usr/lib64/libicui18n.so.50.1.2 lib/libicui18n.so.50
 docker -D cp $container:/usr/lib64/libicuuc.so.50.1.2 lib/libicuuc.so.50
 docker -D cp $container:/usr/lib64/libicudata.so.50.1.2 lib/libicudata.so.50

--- a/bin/php/build.sh
+++ b/bin/php/build.sh
@@ -31,12 +31,19 @@ docker -D cp $container:/php-src-php-$PHP_VERSION/sapi/cli/php .
 mkdir -p ext
 docker -D cp $container:/usr/local/lib/php/extensions/no-debug-non-zts-20170718/. ext/
 
+# Fetch ICU libraries required by INTL extension
+mkdir -p lib
+docker -D cp $container:/usr/lib64/libicui18n.so.50.1.2 lib/libicui18n.so.50
+docker -D cp $container:/usr/lib64/libicuuc.so.50.1.2 lib/libicuuc.so.50
+docker -D cp $container:/usr/lib64/libicudata.so.50.1.2 lib/libicudata.so.50
+docker -D cp $container:/usr/lib64/libicuio.so.50.1.2 lib/libicuio.so.50
+
 docker rm $container
 
 # Put all that in an archive
-tar czf php-$PHP_VERSION.tar.gz php ext
+tar czf php-$PHP_VERSION.tar.gz php ext lib dependencies.yml
 rm php
-rm -rf ext
+rm -rf ext lib
 
 # Upload the archive to AWS S3
 aws s3 cp php-$PHP_VERSION.tar.gz s3://bref-php/bin/ --acl public-read

--- a/bin/php/dependencies.yml
+++ b/bin/php/dependencies.yml
@@ -1,0 +1,6 @@
+extensions:
+    intl:
+        - libicudata.so.50
+        - libicui18n.so.50
+        - libicuio.so.50
+        - libicuuc.so.50

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -297,7 +297,6 @@ class Deployer
     {
         $dependencies = [];
         $dependenciesFile = '.bref/output/.bref/bin/dependencies.yml';
-        $librariesDir = '.bref/output/.bref/bin/lib/';
 
         if ($this->fs->exists($dependenciesFile)) {
             $dependencies = Yaml::parse(file_get_contents($dependenciesFile))['extensions'] ?? [];

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -303,8 +303,7 @@ class Deployer
             $this->fs->remove($dependenciesFile);
         }
 
-        $requiredLibraries = array_unique(call_user_func_array(
-            'array_merge',
+        $requiredLibraries = array_merge(...array_values(
             array_intersect_key($dependencies, array_flip($extensions)) + [[]]
         ));
 

--- a/template/handler.js
+++ b/template/handler.js
@@ -1,6 +1,11 @@
 if (process.env['LAMBDA_TASK_ROOT']) {
+    // add bin directory to PATH to run PHP binary
     process.env['PATH'] = process.env['PATH']
-        + ':' + process.env['LAMBDA_TASK_ROOT'] + '/.bref/bin'; // for PHP
+        + ':' + process.env['LAMBDA_TASK_ROOT'] + '/.bref/bin';
+
+    // add lib directory to LD_LIBRARY_PATH to make PHP binary able to load required libraries
+    process.env['LD_LIBRARY_PATH'] = process.env['LD_LIBRARY_PATH']
+        + ':' + process.env['LAMBDA_TASK_ROOT'] + '/.bref/bin/lib';
 }
 
 const spawn = require('child_process').spawn;


### PR DESCRIPTION
Following up #43, here is a new PR to add INTL as an optional extension.

What's been done:
 * Add `intl.so` build
 * Fetch ICU's libraries and add it to tar
 * According to enabled extensions, the deployer now remove useless libraries
 * Doc update

Since `max_execution_time` has no effect in CLI, I've also updated the PHP configuration example.