### PR TITLE
 Add multipart/form-data support

### DIFF
--- a/src/Bridge/Psr7/RequestFactory.php
+++ b/src/Bridge/Psr7/RequestFactory.php
@@ -133,7 +133,8 @@ class RequestFactory
                     }
 
                     if (preg_match('/filename="([^"]+)"/', $header, $matches)) {
-                        $filename = $matches[1];
+                        $filename = basename($matches[1]);
+                        $filename = strlen($filename) > 0 ? $filename : null;
                     }
                 } elseif (preg_match('/^Content-Type:(.*)$/i', $header, $matches)) {
                     $type = trim($matches[1]);


### PR DESCRIPTION
Hi,

I saw there is no multipart/form-data support, are you interested with that ?

--

There is a detail, if you want to handle binary files you have to do this in your API Gateway settings:
![image](https://user-images.githubusercontent.com/1501825/44746848-d4eb9900-ab0b-11e8-9c74-ee549dc62cda.png)

You can also use a plugin to let serverless framework configure it for you, but I did not tested it: https://github.com/maciejtreder/serverless-apigw-binary

If you want to merge this PR, maybe we should add this to the readme ?
