### PR TITLE
Add session handling into `SymfonyAdapter`

### DIFF
--- a/src/Bridge/Symfony/SymfonyAdapter.php
+++ b/src/Bridge/Symfony/SymfonyAdapter.php
@@ -71,7 +71,14 @@ class SymfonyAdapter implements RequestHandlerInterface
         $symfonyResponse->headers->setCookie(
             new Cookie(
                 session_name(),
-                $this->httpKernel->getContainer()->get('session')->getId()
+                $this->httpKernel->getContainer()->get('session')->getId(),
+                0,
+                "/",
+                null,
+                false,
+                true,
+                false,
+                Cookie::SAMESITE_LAX
             )
         );
     }

--- a/src/Bridge/Symfony/SymfonyAdapter.php
+++ b/src/Bridge/Symfony/SymfonyAdapter.php
@@ -35,20 +35,11 @@ class SymfonyAdapter implements RequestHandlerInterface
 
         $symfonyRequest = $httpFoundationFactory->createRequest($request);
 
-        if (!is_null($symfonyRequest->cookies->get(session_name()))) {
-            $this->httpKernel->getContainer()->get('session')->setId(
-                $symfonyRequest->cookies->get(session_name())
-            );
-        }
+        $this->loadSessionFromCookies($symfonyRequest);
 
         $symfonyResponse = $this->httpKernel->handle($symfonyRequest);
 
-        $symfonyResponse->headers->setCookie(
-            new Cookie(
-                session_name(),
-                $this->httpKernel->getContainer()->get('session')->getId()
-            )
-        );
+        $this->addSessionCookieToResponse($symfonyResponse);
 
         if ($this->httpKernel instanceof TerminableInterface) {
             $this->httpKernel->terminate($symfonyRequest, $symfonyResponse);
@@ -58,5 +49,30 @@ class SymfonyAdapter implements RequestHandlerInterface
         $response = $psr7Factory->createResponse($symfonyResponse);
 
         return $response;
+    }
+
+    /**
+     * @param $symfonyRequest
+     */
+    private function loadSessionFromCookies($symfonyRequest): void
+    {
+        if (!is_null($symfonyRequest->cookies->get(session_name()))) {
+            $this->httpKernel->getContainer()->get('session')->setId(
+                $symfonyRequest->cookies->get(session_name())
+            );
+        }
+    }
+
+    /**
+     * @param $symfonyResponse
+     */
+    private function addSessionCookieToResponse($symfonyResponse): void
+    {
+        $symfonyResponse->headers->setCookie(
+            new Cookie(
+                session_name(),
+                $this->httpKernel->getContainer()->get('session')->getId()
+            )
+        );
     }
 }

--- a/tests/Bridge/Symfony/SymfonyAdapterTest.php
+++ b/tests/Bridge/Symfony/SymfonyAdapterTest.php
@@ -73,7 +73,7 @@ class SymfonyAdapterTest extends TestCase
         );
 
         self::assertSame(
-            sprintf("%s=SESSIONID; path=/; httponly", \session_name()),
+            sprintf("%s=SESSIONID; path=/; httponly; samesite=lax", \session_name()),
             $symfonyResponse->getHeaders()['Set-Cookie'][0]
         );
     }

--- a/tests/Bridge/Symfony/SymfonyAdapterTest.php
+++ b/tests/Bridge/Symfony/SymfonyAdapterTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -90,7 +90,7 @@ class SymfonyAdapterTest extends TestCase
 
             protected function configureContainer(ContainerBuilder $c)
             {
-                $c->register('session_storage', NativeSessionStorage::class);
+                $c->register('session_storage', MockArraySessionStorage::class);
 
                 $c->loadFromExtension('framework', [
                     'secret'  => 'foo',

--- a/tests/Bridge/Symfony/SymfonyAdapterTest.php
+++ b/tests/Bridge/Symfony/SymfonyAdapterTest.php
@@ -72,8 +72,8 @@ class SymfonyAdapterTest extends TestCase
             )
         );
 
-        self::assertContains(
-            sprintf("%s=SESSIONID", \session_name()),
+        self::assertSame(
+            sprintf("%s=SESSIONID; path=/; httponly", \session_name()),
             $symfonyResponse->getHeaders()['Set-Cookie'][0]
         );
     }


### PR DESCRIPTION
As per #59, some additional injection is needed on the `Request` and `Response` objects in order to handle the `PHPSESSID` cookie sent in the request headers, or to add the `Set-Cookie` header to the response when using the Symfony framework with Lambda / Bref