### PR TITLE
add pre-build hook to deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,11 @@ You can execute additional scripts by using a *build hook*. Those can be defined
 
 ```yaml
 hooks:
+    # pre-build hooks are run *before* the deployment package is created (in the current working directory)
+    pre-build:
+        - 'yarn encore production'
+        
+    # build hooks are run on the deployment package *during* its creation (in .bref/)  
     build:
         - 'npm install'
 ```

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -126,6 +126,17 @@ class Deployer
         }
         $progress->advance();
 
+        // Run pre-build hooks defined in .bref.yml
+        $progress->setMessage('Running pre-build hooks');
+        $progress->display();
+        $buildHooks = $projectConfig['hooks']['pre-build'] ?? [];
+        foreach ($buildHooks as $buildHook) {
+            $progress->setMessage('Running pre-build hook: ' . $buildHook);
+            $progress->display();
+            $this->runInWorkingDirectory($buildHook);
+        }
+        $progress->advance();
+
         $progress->setMessage('Building the project in the `.bref/output` directory');
         $progress->display();
         $this->copyProjectToOutputDirectory();
@@ -195,6 +206,13 @@ class Deployer
             $this->runLocally($buildHook);
         }
         $progress->advance();
+    }
+
+    private function runInWorkingDirectory(string $command) : void
+    {
+        $process = new Process($command);
+        $process->setTimeout(null);
+        $process->mustRun();
     }
 
     private function runLocally(string $command) : void


### PR DESCRIPTION
The Symfony best practices suggest to run `yarn encore production` during deployment (https://symfony.com/doc/current/frontend/encore/simple-example.html). However, when adding this as a build hook in `.bref.yml` the process blows up with:

```
In Process.php line 223:

  The command "yarn encore production" failed.

  Exit Code: 1(General error)

  Working directory: .bref/output

  Output:
  ================
  yarn run v1.9.4
  $ ~/Projects/bref-sf4/.bref/output/node_modules/.bin/encore production
  info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.


  Error Output:
  ================
  internal/modules/cjs/loader.js:583
      throw err;
      ^

  Error: Cannot find module '../lib/config/parse-runtime'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
```

Running the command in the current working directory *before* the build artefact is created runs smoothly. Therefore the ability to add it as a `pre-build` hook in the deployment process allows us to automate the generation of compiled assets during the build.