### PR TITLE
Fix empty session value in Symfony adapter

### DIFF
--- a/src/Bridge/Symfony/SymfonyAdapter.php
+++ b/src/Bridge/Symfony/SymfonyAdapter.php
@@ -48,14 +48,14 @@ class SymfonyAdapter implements RequestHandlerInterface
         return (new DiactorosFactory)->createResponse($symfonyResponse);
     }
 
-    private function loadSessionFromRequest(Request $symfonyRequest): ?string
+    private function loadSessionFromRequest(Request $symfonyRequest): string
     {
         if ($this->hasSessionsDisabled()) {
-            return null;
+            return '';
         }
 
         $this->httpKernel->getContainer()->get('session')->setId(
-            $sessionId = $symfonyRequest->cookies->get(session_name())
+            $sessionId = $symfonyRequest->cookies->get(session_name(), '')
         );
 
         return $sessionId;


### PR DESCRIPTION
Sorry about this change.
The mock session handler used within the tests takes the NULL value (if no cookie is present) and sets it as the id. This allows the subsequent check upon response to function correctly.
However, when using the native `session_id` function in production, the NULL value is not returned and `session_id` returns an empty string.
So as to meet these requirements we should instead replace NULL with an empty string to signify no session being present.