### PR TITLE
add support for HTTP_HOST server var passed in from Lambda event

### DIFF
--- a/src/Bridge/Psr7/RequestFactory.php
+++ b/src/Bridge/Psr7/RequestFactory.php
@@ -91,6 +91,10 @@ class RequestFactory
             'REQUEST_URI' => $uri,
         ];
 
+        if (isset($headers['Host'])) {
+            $server['HTTP_HOST'] = $headers['Host'];
+        }
+
         return new ServerRequest(
             $server,
             $files,

--- a/tests/Bridge/Psr7/RequestFactoryTest.php
+++ b/tests/Bridge/Psr7/RequestFactoryTest.php
@@ -267,4 +267,16 @@ RAW
         self::assertEquals('POST', $request->getMethod());
         self::assertEquals(['foo' => 'bar'], $request->getParsedBody());
     }
+
+    public function test HTTP_HOST is set() {
+        $request = RequestFactory::fromLambdaEvent([
+            'headers' => [
+                'Host' => 'www.example.com',
+            ],
+        ]);
+
+        $serverParams = $request->getServerParams();
+
+        self::assertSame('www.example.com', $serverParams['HTTP_HOST']);
+    }
 }

--- a/tests/Bridge/Psr7/RequestFactoryTest.php
+++ b/tests/Bridge/Psr7/RequestFactoryTest.php
@@ -268,7 +268,8 @@ RAW
         self::assertEquals(['foo' => 'bar'], $request->getParsedBody());
     }
 
-    public function test HTTP_HOST is set() {
+    public function test HTTP_HOST is set()
+    {
         $request = RequestFactory::fromLambdaEvent([
             'headers' => [
                 'Host' => 'www.example.com',

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 namespace Bref\Test;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 class CliTest extends TestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\ProcessFailedException
-     * @expectedExceptionMessage The files `bref.php` and `serverless.yml` are required to deploy
-     */
     public function test deploying requires mandatory files to exist()
     {
+        $this->expectException(ProcessFailedException::class);
+        $this->expectExceptionMessage('The files `bref.php` and `serverless.yml` are required to deploy');
+
         $process = new Process(__DIR__ . '/../bref deploy', __DIR__ . '/Fixture/EmptyDirectory');
         $process->mustRun();
     }

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 namespace Bref\Test;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
 class CliTest extends TestCase
 {
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\ProcessFailedException
+     * @expectedExceptionMessage The files `bref.php` and `serverless.yml` are required to deploy
+     */
     public function test deploying requires mandatory files to exist()
     {
-        $this->expectException(ProcessFailedException::class);
-        $this->expectExceptionMessage('The files `bref.php` and `serverless.yml` are required to deploy');
-
         $process = new Process(__DIR__ . '/../bref deploy', __DIR__ . '/Fixture/EmptyDirectory');
         $process->mustRun();
     }


### PR DESCRIPTION
The `$_SERVER['HTTP_HOST']` global isn't available within Bref for obvious reasons, however it is useful in many applications to have access to the hostname the script is running on.

The PSR-7 `Request` object allows us to create `$server` variables but they need to be explicitly converted from the Lambda event in order to be used.

When using Symfony's router to generate absolute URLs, the URLs will all point to `localhost` unless `HTTP_HOST` is set.