### PR TITLE
Added REQUEST_TIME_FLOAT server var

### DIFF
--- a/src/Bridge/Psr7/RequestFactory.php
+++ b/src/Bridge/Psr7/RequestFactory.php
@@ -86,6 +86,7 @@ class RequestFactory
             'SERVER_PROTOCOL' => $protocolVersion,
             'REQUEST_METHOD' => $method,
             'REQUEST_TIME' => $event['requestContext']['requestTimeEpoch'] ?? time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
             'QUERY_STRING' => $queryString,
             'DOCUMENT_ROOT' => getcwd(),
             'REQUEST_URI' => $uri,

--- a/tests/Bridge/Psr7/RequestFactoryTest.php
+++ b/tests/Bridge/Psr7/RequestFactoryTest.php
@@ -36,6 +36,8 @@ class RequestFactoryTest extends TestCase
         self::assertEquals([], $request->getAttributes());
         $serverParams = $request->getServerParams();
         unset($serverParams['DOCUMENT_ROOT']);
+        // there is no aws lambda native reqestContext key with microsecond precision, therefore ignore it.
+        unset($serverParams['REQUEST_TIME_FLOAT']);
         self::assertEquals([
             'SERVER_PROTOCOL' => '1.1',
             'REQUEST_METHOD' => 'GET',


### PR DESCRIPTION
As supported by native php

http://php.net/manual/en/reserved.variables.server.php

> 'REQUEST_TIME_FLOAT'
The timestamp of the start of the request, with microsecond precision