### PR TITLE
Refactor the PSR-7 request and lambda response creation code to allow for custom implementations

### DIFF
--- a/src/Http/LambdaResponseArraySerializer.php
+++ b/src/Http/LambdaResponseArraySerializer.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bref\Http;
+
+use Psr\Http\Message\ResponseInterface;
+
+class LambdaResponseArraySerializer
+{
+    /**
+     * @param ResponseInterface $response
+     * @return array
+     */
+    public function __invoke(ResponseInterface $response): array
+    {
+        $headers = $response->getHeaders();
+
+        // The headers must be a JSON object. If the PHP array is empty it is
+        // serialized to `[]` (we want `{}`) so we force it to an empty object.
+        if (empty($headers)) {
+            $multiValueHeaders = new \stdClass();
+        } else {
+            $multiValueHeaders = [];
+
+            foreach ($headers as $name => $values) {
+                $multiValueHeaders[$this->filterHeader($name)] = $values;
+            }
+        }
+
+        // This is the format required by the AWS_PROXY lambda integration
+        // @see https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
+        return [
+            'isBase64Encoded' => false,
+            'statusCode' => $response->getStatusCode(),
+            'multiValueHeaders' => $multiValueHeaders,
+            'body' => (string)$response->getBody(),
+        ];
+    }
+
+    /**
+     * Filter a header name to wordcase
+     *
+     * @see https://github.com/zendframework/zend-diactoros/blob/754a2ceb7ab753aafe6e3a70a1fb0370bde8995c/src/Response/SapiEmitterTrait.php#L96
+     * @param string $header
+     * @return string
+     */
+    private function filterHeader($header): string
+    {
+        $filtered = str_replace('-', ' ', $header);
+        $filtered = ucwords($filtered);
+        return str_replace(' ', '-', $filtered);
+    }
+}

--- a/tests/Http/LambdaResponseArraySerializerTest.php
+++ b/tests/Http/LambdaResponseArraySerializerTest.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+namespace Bref\Test\Http;
+
+use Bref\Http\LambdaResponse;
+use Bref\Http\LambdaResponseArraySerializer;
+use PHPUnit\Framework\TestCase;
+use Zend\Diactoros\Response\EmptyResponse;
+use Zend\Diactoros\Response\HtmlResponse;
+use Zend\Diactoros\Response\JsonResponse;
+
+class LambdaResponseArraySerializerTest extends TestCase
+{
+    /**
+     * @return LambdaResponseArraySerializer
+     */
+    private function buildSerializerWithMultiValueHeaders(): LambdaResponseArraySerializer
+    {
+        return new LambdaResponseArraySerializer(true);
+    }
+
+    /**
+     * @return LambdaResponseArraySerializer
+     */
+    private function buildSerializerWithSingleValueHeaders(): LambdaResponseArraySerializer
+    {
+        return new LambdaResponseArraySerializer(false);
+    }
+
+    /**
+     * @test
+     */
+    public function test I can create a response from HTML content()
+    {
+        $serializer = $this->buildSerializerWithSingleValueHeaders();
+
+        $response = $serializer(new HtmlResponse('<p>Hello world!</p>'));
+        $this->assertArrayPayload($response, [
+            'isBase64Encoded' => false,
+            'statusCode' => 200,
+            'headers' => [
+                'Content-Type' => 'text/html; charset=utf-8',
+            ],
+            'body' => '<p>Hello world!</p>',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function test I can create a response from a PSR7 response()
+    {
+        $serializer = $this->buildSerializerWithSingleValueHeaders();
+
+        $psr7Response = new JsonResponse(['foo' => 'bar'], 404);
+
+        $response = $serializer($psr7Response);
+        $this->assertArrayPayload($response, [
+            'isBase64Encoded' => false,
+            'statusCode' => 404,
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+            'body' => json_encode(['foo' => 'bar']),
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function test nested arrays in headers are flattened()
+    {
+        $serializer = $this->buildSerializerWithSingleValueHeaders();
+
+        $psr7Response = new EmptyResponse;
+        $psr7Response = $psr7Response->withHeader('foo', ['bar', 'baz']);
+
+        $response = $serializer($psr7Response);
+        $this->assertArrayPayload($response, [
+            'isBase64Encoded' => false,
+            'statusCode' => 204,
+            'headers' => [
+                'Foo' => 'baz',
+            ],
+            'body' => '',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function test multivalueheader defaulthandling()
+    {
+        $serializer = new LambdaResponseArraySerializer();
+
+        $psr7Response = new EmptyResponse;
+        $psr7Response = $psr7Response->withHeader('foo', ['bar', 'baz']);
+
+        $response = $serializer($psr7Response);
+        $this->assertArrayPayload($response, [
+            'isBase64Encoded' => false,
+            'statusCode' => 204,
+            'multiValueHeaders' => [
+                'Foo' => ['bar', 'baz']
+            ],
+            'body' => '',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function test nested arrays in multivalueheaders()
+    {
+        $serializer = $this->buildSerializerWithMultiValueHeaders();
+
+        $psr7Response = new EmptyResponse;
+        $psr7Response = $psr7Response->withHeader('foo', ['bar', 'baz']);
+
+        $response = $serializer($psr7Response);
+        $this->assertArrayPayload($response, [
+            'isBase64Encoded' => false,
+            'statusCode' => 204,
+            'multiValueHeaders' => [
+                'Foo' => ['bar', 'baz']
+            ],
+            'body' => '',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function test empty headers are considered objects()
+    {
+        $serializer = $this->buildSerializerWithSingleValueHeaders();
+
+        $response = $serializer(new EmptyResponse);
+
+        // Make sure that the headers are `"headers":{}` (object) and not `"headers":[]` (array)
+        self::assertEquals('{"isBase64Encoded":false,"statusCode":204,"headers":{},"body":""}', json_encode($response));
+    }
+
+    /**
+     * @test
+     */
+    public function test empty multivalueheaders are considered objects()
+    {
+        $serializer = $this->buildSerializerWithMultiValueHeaders();
+
+        $response = $serializer(new EmptyResponse);
+
+        // Make sure that the multi-value headers are `"multiValueHeaders":{}` (object) and not `"multiValueHeaders":[]` (array)
+        self::assertEquals('{"isBase64Encoded":false,"statusCode":204,"multiValueHeaders":{},"body":""}', json_encode($response));
+    }
+
+
+    private function assertArrayPayload(array $response, array $expected)
+    {
+        self::assertEquals($expected, $response);
+    }
+}


### PR DESCRIPTION
Hi @mnapoli, thanks for your work on Bref. It's really great!

I recently had a use-case where I needed to set `"isBaseEncoded" => true` on the lambda response array and realised there was no easy way to override that code.

This pull request abstracts the PSR-7 request and lambda response creation code to allow for custom implementations (eg. to achieve the `isBaseEncoded` example above).