### PR TITLE
Fix Laravel's `runningInConsole()` on AWS Lambda

### DIFF
--- a/docs/Laravel.md
+++ b/docs/Laravel.md
@@ -1,6 +1,19 @@
 # Deploying Laravel applications
 
-Here is an example of what your `bref.php` file should contain:
+Deploying Laravel applications requires a few changes for everything to work perfectly.
+
+First let's change `bootstrap/app.php` to use the Bref application class:
+
+```diff
+- $app = new Illuminate\Foundation\Application(
++ $app = new Bref\Bridge\Laravel\Application(
+    realpath(__DIR__ . '/../')
+);
+```
+
+This class extends the Laravel application class to set a few Bref-specific helpers. Everything else stays Laravel.
+
+Then let's write the `bref.php` file. This file will now be the entrypoint of the application and replace `public/index.php`. Here is what it should contain:
 
 ```php
 <?php
@@ -12,28 +25,27 @@ require __DIR__.'/vendor/autoload.php';
 $app = require_once __DIR__.'/bootstrap/app.php';
 
 // Laravel does not create that directory automatically so we have to create it
+// You can remove this if you do not use views in your application (e.g. for an API)
 if (!is_dir(storage_path('framework/views'))) {
     if (!mkdir(storage_path('framework/views'), 0755, true)) {
         die('Cannot create directory ' . storage_path('framework/views'));
     }
 }
 
-$kernel = $app->make(Illuminate\Contracts\Http\Kernel::class);
-
 $bref = new \Bref\Application;
-$bref->httpHandler(new Bref\Bridge\Laravel\LaravelAdapter($kernel));
+$bref->httpHandler($app->getBrefHttpAdapter());
 $bref->run();
 ```
 
 When generating the optimized config absolute paths will be everywhere, and they will not work because your machine and the lambda environment do not match. To avoid that problem, change `bootstrap/app.php` as shown below. The `APP_DIR` variable will allow us to replace the absolute path by `.` (relative path) when generating the lambda.
 
 ```php
-$app = new Illuminate\Foundation\Application(
+$app = new Bref\Bridge\Laravel\Application(
     env('APP_DIR', realpath(__DIR__.'/../'))
 );
 ```
 
-The filesystem is readonly on lambdas except for `/tmp`. Because of that you need to customize the storage path. Add this line in `bootstrap/app.php` after `$app = new Illuminate\Foundation\Application`:
+The filesystem is readonly on lambdas except for `/tmp`. Because of that you need to customize the storage path. Add this line in `bootstrap/app.php` after `$app = new Bref\Bridge\Laravel\Application`:
 
 ```php
 /*
@@ -113,3 +125,5 @@ Route::get('/dev', function () {
     return view('welcome');
 });
 ```
+
+However if you setup a custom domain in API Gateway the `/dev` prefix will disappear.

--- a/docs/Laravel.md
+++ b/docs/Laravel.md
@@ -39,9 +39,10 @@ $bref->run();
 
 When generating the optimized config absolute paths will be everywhere, and they will not work because your machine and the lambda environment do not match. To avoid that problem, change `bootstrap/app.php` as shown below. The `APP_DIR` variable will allow us to replace the absolute path by `.` (relative path) when generating the lambda.
 
-```php
+```diff
 $app = new Bref\Bridge\Laravel\Application(
-    env('APP_DIR', realpath(__DIR__.'/../'))
+-    realpath(__DIR__ . '/../')
++    env('APP_DIR', realpath(__DIR__.'/../'))
 );
 ```
 

--- a/src/Bridge/Laravel/Application.php
+++ b/src/Bridge/Laravel/Application.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Bref\Bridge\Laravel;
+
+use Illuminate\Contracts\Http\Kernel;
+
+/**
+ * Overrides the base Laravel application class for Bref specific behaviors.
+ */
+class Application extends \Illuminate\Foundation\Application
+{
+    private $isArtisanConsole = null;
+
+    /**
+     * Configure Laravel to run as HTTP handler in Bref
+     * and return the correct adapter.
+     *
+     * Usage example:
+     *
+     *     $laravel = new \Bref\Bridge\Laravel\Application(...);
+     *
+     *     $bref = new \Bref\Application;
+     *     $bref->httpHandler($laravel->getBrefHttpAdapter());
+     *     $bref->run();
+     */
+    public function getBrefHttpAdapter(): LaravelAdapter
+    {
+        $this->overrideRunningInConsole(false);
+
+        $kernel = $this->make(Kernel::class);
+
+        return new LaravelAdapter($kernel);
+    }
+
+    /**
+     * Bref always runs using the `php-cli` binary on AWS lambda.
+     *
+     * This is a problem because it tricks Laravel into thinking that it
+     * runs the Artisan console and not the HTTP application...
+     * This can cause issues in some apps or packages.
+     *
+     * To fix this we override the method to force its return value:
+     * - most of the time we don't override the value
+     * - when running in Lambda in HTTP we override it to return `false`
+     */
+    public function runningInConsole()
+    {
+        // This allows us to override the value to return
+        if ($this->isArtisanConsole !== null) {
+            return $this->isArtisanConsole;
+        }
+
+        // By default we return the result of the parent method
+        return parent::runningInConsole();
+    }
+
+    public function overrideRunningInConsole(bool $value)
+    {
+        $this->isArtisanConsole = $value;
+    }
+}

--- a/tests/Bridge/Laravel/ApplicationTest.php
+++ b/tests/Bridge/Laravel/ApplicationTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Bref\Test\Bridge\Laravel;
+
+use Bref\Bridge\Laravel\Application;
+use Illuminate\Contracts\Http\Kernel;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ApplicationTest extends TestCase
+{
+    public function test runningInConsole returns the parent result by default()
+    {
+        $defaultLaravelApp = new \Illuminate\Foundation\Application(__DIR__);
+        $brefLaravelApp = new Application(__DIR__);
+
+        self::assertSame($defaultLaravelApp->runningInConsole(), $brefLaravelApp->runningInConsole());
+    }
+
+    public function test runningInConsole can be overridden()
+    {
+        $app = new Application(__DIR__);
+
+        $app->overrideRunningInConsole(true);
+        self::assertTrue($app->runningInConsole());
+
+        $app->overrideRunningInConsole(false);
+        self::assertFalse($app->runningInConsole());
+    }
+
+    public function test can return an http adapter()
+    {
+        $app = new Application(__DIR__);
+        $app->singleton(Kernel::class, \Illuminate\Foundation\Http\Kernel::class);
+
+        $adapter = $app->getBrefHttpAdapter();
+
+        self::assertInstanceOf(RequestHandlerInterface::class, $adapter);
+    }
+
+    public function test is not in console when running http()
+    {
+        $app = new Application(__DIR__);
+        $app->singleton(Kernel::class, \Illuminate\Foundation\Http\Kernel::class);
+
+        $app->getBrefHttpAdapter();
+
+        self::assertFalse($app->runningInConsole());
+    }
+}

--- a/tests/Bridge/Laravel/LaravelAdapterTest.php
+++ b/tests/Bridge/Laravel/LaravelAdapterTest.php
@@ -3,9 +3,8 @@ declare(strict_types=1);
 
 namespace Bref\Test\Bridge\Laravel;
 
-use Bref\Bridge\Laravel\LaravelAdapter;
+use Bref\Bridge\Laravel\Application;
 use Illuminate\Contracts\Http\Kernel;
-use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Router;
@@ -34,7 +33,7 @@ class LaravelAdapterTest extends TestCase
             return new Response('Hello world!');
         });
 
-        $adapter = new LaravelAdapter($app->make(Kernel::class));
+        $adapter = $app->getBrefHttpAdapter();
         $response = $adapter->handle(new ServerRequest([], [], '/'));
 
         self::assertSame('Hello world!', (string) $response->getBody());
@@ -50,7 +49,7 @@ class LaravelAdapterTest extends TestCase
             return new Response('Hello ' . $request->header('X-HELLO'));
         });
 
-        $adapter = new LaravelAdapter($app->make(Kernel::class));
+        $adapter = $app->getBrefHttpAdapter();
         $request = new ServerRequest([], [], '/');
         $request = $request->withHeader('X-HELLO', 'world!');
         $response = $adapter->handle($request);


### PR DESCRIPTION
Laravel's application has a `runningInConsole()` method that returns `true` if the PHP binary used to run the process is `php-cli`.

This is a problem because it tricks Laravel into thinking that it runs the Artisan console and not the HTTP application... This can cause issues in some apps or packages.

To fix this we override the method to force its return value:
 - most of the time we don't override the value
 - when running in Lambda in HTTP we override it to return `false`