### PR TITLE
Append querystring to uri

### DIFF
--- a/src/Bridge/Psr7/RequestFactory.php
+++ b/src/Bridge/Psr7/RequestFactory.php
@@ -43,6 +43,9 @@ class RequestFactory
          */
         $queryString = http_build_query($event['queryStringParameters'] ?? []);
         parse_str($queryString, $query);
+        if (!empty($queryString)) {
+            $uri .= '?' . $queryString;
+        }
 
         $cookies = [];
         if (isset($headers['Cookie'])) {

--- a/src/Bridge/Psr7/RequestFactory.php
+++ b/src/Bridge/Psr7/RequestFactory.php
@@ -43,7 +43,7 @@ class RequestFactory
          */
         $queryString = http_build_query($event['queryStringParameters'] ?? []);
         parse_str($queryString, $query);
-        if (!empty($queryString)) {
+        if (! empty($queryString)) {
             $uri .= '?' . $queryString;
         }
 

--- a/tests/Bridge/Psr7/RequestFactoryTest.php
+++ b/tests/Bridge/Psr7/RequestFactoryTest.php
@@ -29,7 +29,7 @@ class RequestFactoryTest extends TestCase
         self::assertEquals('GET', $request->getMethod());
         self::assertEquals(['foo' => 'bar', 'bim' => 'baz'], $request->getQueryParams());
         self::assertEquals('1.1', $request->getProtocolVersion());
-        self::assertEquals('/test', $request->getUri()->__toString());
+        self::assertEquals('/test?foo=bar&bim=baz', $request->getUri()->__toString());
         self::assertEquals('', $request->getBody()->getContents());
         self::assertEquals([], $request->getAttributes());
         $serverParams = $request->getServerParams();
@@ -41,9 +41,9 @@ class RequestFactoryTest extends TestCase
             'REQUEST_METHOD' => 'GET',
             'REQUEST_TIME' => $currentTimestamp,
             'QUERY_STRING' => 'foo=bar&bim=baz',
-            'REQUEST_URI' => '/test',
+            'REQUEST_URI' => '/test?foo=bar&bim=baz',
         ], $serverParams);
-        self::assertEquals('/test', $request->getRequestTarget());
+        self::assertEquals('/test?foo=bar&bim=baz', $request->getRequestTarget());
         self::assertEquals([], $request->getHeaders());
     }
 


### PR DESCRIPTION
I'm not 100% sure, but doesn't the Query string belong in the URI? According to https://www.php-fig.org/psr/psr-7/

Eg. if I dump my $_SERVER in a normal request, the querystring is appended to the REQUEST_URI