### PR TITLE
Fix phpstan errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.bref/
 /.phpcs-cache
 /composer.lock
+var/cache/

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -81,7 +81,7 @@ class Deployer
             if ($stage !== null) {
                 $serverlessCommand .= ' --stage ' . escapeshellarg($stage);
             }
-            $process = new Process([$serverlessCommand, '.bref/output']);
+            $process = new Process([$serverlessCommand], '.bref/output');
             $process->setTimeout(null);
             $completeDeployOutput = '';
             $process->mustRun(function ($type, $buffer) use ($io, $progress, &$completeDeployOutput): void {

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -203,7 +203,7 @@ class Deployer
 
     private function runLocally(string $command): void
     {
-        $process = new Process([$command, '.bref/output']);
+        $process = new Process([$command], '.bref/output');
         $process->setTimeout(null);
         $process->mustRun();
     }

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -59,7 +59,7 @@ class Deployer
             array_keys($parameters)
         ));
 
-        $process = new Process('serverless invoke local ' . $p, '.bref/output');
+        $process = new Process(['serverless invoke local ' . $p, '.bref/output']);
         $process->setEnv([
             'BREF_LOCAL' => 'BREF_LOCAL',
         ]);
@@ -81,7 +81,7 @@ class Deployer
             if ($stage !== null) {
                 $serverlessCommand .= ' --stage ' . escapeshellarg($stage);
             }
-            $process = new Process($serverlessCommand, '.bref/output');
+            $process = new Process([$serverlessCommand, '.bref/output']);
             $process->setTimeout(null);
             $completeDeployOutput = '';
             $process->mustRun(function ($type, $buffer) use ($io, $progress, &$completeDeployOutput): void {
@@ -151,7 +151,7 @@ class Deployer
              */
             $defaultUrl = 'https://s3.amazonaws.com/bref-php/bin/php-' . $phpVersion . '.tar.gz';
             $url = $projectConfig['php']['url'] ?? $defaultUrl;
-            (new Process("curl -sSL $url -o .bref/bin/php/php-$phpVersion.tar.gz"))
+            (new Process(["curl -sSL $url -o .bref/bin/php/php-$phpVersion.tar.gz"]))
                 ->setTimeout(null)
                 ->mustRun();
         }
@@ -160,7 +160,7 @@ class Deployer
         $progress->setMessage('Installing the PHP binary');
         $progress->display();
         $this->fs->mkdir('.bref/output/.bref/bin');
-        (new Process("tar -xzf .bref/bin/php/php-$phpVersion.tar.gz -C .bref/output/.bref/bin"))
+        (new Process(["tar -xzf .bref/bin/php/php-$phpVersion.tar.gz -C .bref/output/.bref/bin"]))
             ->mustRun();
         // Set correct permissions on the file
         $this->fs->chmod('.bref/output/.bref/bin', 0755);
@@ -203,7 +203,7 @@ class Deployer
 
     private function runLocally(string $command): void
     {
-        $process = new Process($command, '.bref/output');
+        $process = new Process([$command, '.bref/output']);
         $process->setTimeout(null);
         $process->mustRun();
     }

--- a/src/Console/Deployer.php
+++ b/src/Console/Deployer.php
@@ -59,7 +59,7 @@ class Deployer
             array_keys($parameters)
         ));
 
-        $process = new Process(['serverless invoke local ' . $p, '.bref/output']);
+        $process = new Process(['serverless invoke local ' . $p], '.bref/output');
         $process->setEnv([
             'BREF_LOCAL' => 'BREF_LOCAL',
         ]);

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -13,7 +13,7 @@ class CliTest extends TestCase
      */
     public function test deploying requires mandatory files to exist()
     {
-        $process = new Process(__DIR__ . '/../bref deploy', __DIR__ . '/Fixture/EmptyDirectory');
+        $process = new Process([__DIR__ . '/../bref deploy', __DIR__ . '/Fixture/EmptyDirectory']);
         $process->mustRun();
     }
 }

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -13,7 +13,7 @@ class CliTest extends TestCase
      */
     public function test deploying requires mandatory files to exist()
     {
-        $process = new Process([__DIR__ . '/../bref deploy', __DIR__ . '/Fixture/EmptyDirectory']);
+        $process = new Process([__DIR__ . '/../bref deploy'], __DIR__ . '/Fixture/EmptyDirectory');
         $process->mustRun();
     }
 }

--- a/tests/JsHandler/JsHandlerTest.php
+++ b/tests/JsHandler/JsHandlerTest.php
@@ -60,7 +60,7 @@ class JsHandlerTest extends TestCase
 
     private function runFile(string $file, array $event = []): Process
     {
-        $process = new Process('node runner.js ' . escapeshellarg(json_encode($event)), __DIR__);
+        $process = new Process(['node runner.js ' . escapeshellarg(json_encode($event)), __DIR__]);
         $process->setEnv([
             'LAMBDA_TASK_ROOT' => __DIR__,
             'TMP_DIRECTORY' => __DIR__ . '/tmp',

--- a/tests/JsHandler/JsHandlerTest.php
+++ b/tests/JsHandler/JsHandlerTest.php
@@ -60,7 +60,7 @@ class JsHandlerTest extends TestCase
 
     private function runFile(string $file, array $event = []): Process
     {
-        $process = new Process(['node runner.js ' . escapeshellarg(json_encode($event)), __DIR__]);
+        $process = new Process(['node runner.js ' . escapeshellarg(json_encode($event))], __DIR__);
         $process->setEnv([
             'LAMBDA_TASK_ROOT' => __DIR__,
             'TMP_DIRECTORY' => __DIR__ . '/tmp',


### PR DESCRIPTION
Attempt to fix phpstan, but still phpunit fail:

PHPUnit 6.5.13 by Sebastian Bergmann and contributors.

...........E..EE........F......FFFFF                              36 / 36 (100%)

Time: 8.16 seconds, Memory: 18.00MB

There were 3 errors:

1) Bref\Test\Bridge\Psr7\RequestFactoryTest::test multipart form data is supported
InvalidArgumentException: Can't find multi-part content

\bref\vendor\riverline\multipart-parser\src\Riverline\MultiPartParser\Part.php:109
\bref\src\Bridge\Psr7\RequestFactory.php:63
\bref\tests\Bridge\Psr7\RequestFactoryTest.php:104

2) Bref\Test\Bridge\Psr7\RequestFactoryTest::test arrays in name are supported with multipart form data
InvalidArgumentException: Can't find multi-part content

\bref\vendor\riverline\multipart-parser\src\Riverline\MultiPartParser\Part.php:109
\bref\src\Bridge\Psr7\RequestFactory.php:63
\bref\tests\Bridge\Psr7\RequestFactoryTest.php:160

3) Bref\Test\Bridge\Psr7\RequestFactoryTest::test files are supported with multipart form data
InvalidArgumentException: Can't find multi-part content

\bref\vendor\riverline\multipart-parser\src\Riverline\MultiPartParser\Part.php:109
\bref\src\Bridge\Psr7\RequestFactory.php:63
\bref\tests\Bridge\Psr7\RequestFactoryTest.php:193

--

There were 6 failures:

1) Bref\Test\CliTest::test deploying requires mandatory files to exist
Failed asserting that exception message 'The command ""\bref\tests/../bref deploy" "\bref\tests/Fixture/EmptyDirectory"" failed.

Exit Code: 1(General error)

Working directory: \bref

Output:
================


Error Output:
================
'"\bref\tests/../bref deploy"' is not recognized as an internal or external command,
operable program or batch file.
' contains 'The files `bref.php` and `serverless.yml` are required to deploy'.

2) Bref\Test\JsHandler\JsHandlerTest::test PHP stdout is forwarded to Node stdout
'"node runner.js \"[]\""' is not recognized as an internal or external command,
operable program or batch file.

Failed asserting that 1 matches expected 0.

\bref\tests\JsHandler\JsHandlerTest.php:82
\bref\tests\JsHandler\JsHandlerTest.php:20

3) Bref\Test\JsHandler\JsHandlerTest::test PHP stderr is forwarded to Node stdout
'"node runner.js \"[]\""' is not recognized as an internal or external command,
operable program or batch file.

Failed asserting that 1 matches expected 0.

\bref\tests\JsHandler\JsHandlerTest.php:82
\bref\tests\JsHandler\JsHandlerTest.php:28

4) Bref\Test\JsHandler\JsHandlerTest::test PHP handler can return a response
'"node runner.js \"[]\""' is not recognized as an internal or external command,
operable program or batch file.

Failed asserting that 1 matches expected 0.

\bref\tests\JsHandler\JsHandlerTest.php:82
\bref\tests\JsHandler\JsHandlerTest.php:36

5) Bref\Test\JsHandler\JsHandlerTest::test PHP handler receives the lambda event
The system cannot find the path specified.

Failed asserting that 1 matches expected 0.

\bref\tests\JsHandler\JsHandlerTest.php:82
\bref\tests\JsHandler\JsHandlerTest.php:48

6) Bref\Test\JsHandler\JsHandlerTest::test PHP errors are forwarded by Node
'"node runner.js \"[]\""' is not recognized as an internal or external command,
operable program or batch file.

Failed asserting that 1 matches expected 0.

\bref\tests\JsHandler\JsHandlerTest.php:82
\bref\tests\JsHandler\JsHandlerTest.php:56

ERRORS!
Tests: 36, Assertions: 53, Errors: 3, Failures: 6.