### PR TITLE
use $event['path'] to get route

### DIFF
--- a/src/Bridge/Psr7/RequestFactory.php
+++ b/src/Bridge/Psr7/RequestFactory.php
@@ -24,7 +24,7 @@ class RequestFactory
         $bodyString = $event['body'] ?? '';
         $parsedBody = null;
         $files = [];
-        $uri = $event['requestContext']['path'] ?? '/';
+        $uri = $event['path'] ?? '/';
         $headers = $event['headers'] ?? [];
         $protocolVersion = $event['requestContext']['protocol'] ?? '1.1';
 

--- a/tests/Bridge/Psr7/RequestFactoryTest.php
+++ b/tests/Bridge/Psr7/RequestFactoryTest.php
@@ -20,9 +20,9 @@ class RequestFactoryTest extends TestCase
             ],
             'requestContext' => [
                 'protocol' => '1.1',
-                'path' => '/test',
                 'requestTimeEpoch' => $currentTimestamp,
             ],
+            'path' => '/test',
             'headers' => [],
         ]);
 


### PR DESCRIPTION
`RequestFactory` currently uses `$event['requestContext']['path']` to figure out the route, although using the new SAM Local / runtime API system with the following config:

```
Resources:
    DemoFunction:
        Properties:
            Events:
                # ...
                HttpSubPaths:
                    Type: Api
                    Properties:
                        Path: /{proxy+}
                        Method: ANY
```

results in `No route found for "POST /{proxy+}"` when `POST`ing using SAM local (although still works on prod).

Dumping `$event['requestContext']` on SAM local shows:

```
["path"]=>
    string(9) "/{proxy+}"
```

But we now have access to both `$event['path']` _and_ `$event['pathParameters']['proxy']` instead, which both appear to give the current URL