### PR TITLE
Add a client for the Lambda runtime API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     ],
     "require": {
         "php": "^7.2.0",
+        "ext-curl": "*",
         "ext-json": "*",
         "mnapoli/silly": "^1.7",
         "symfony/filesystem": "^3.1|^4.0",

--- a/runtime/default/bootstrap
+++ b/runtime/default/bootstrap
@@ -1,0 +1,14 @@
+#!/opt/bin/php
+<?php
+
+ini_set('display_errors', '1');
+error_reporting(E_ALL);
+
+while (true) {
+    $handler = getenv('LAMBDA_TASK_ROOT') . '/' . getenv('_HANDLER') . '.php';
+    $handler = escapeshellarg($handler);
+
+    // We redirect stderr to stdout and use passthru so that everything
+    // written on the output ends up in Cloudwatch automatically
+    passthru("/opt/bin/php $handler 2>&1");
+}

--- a/runtime/default/build.sh
+++ b/runtime/default/build.sh
@@ -95,8 +95,7 @@ cp /usr/lib64/libicuuc.so.50.1.2 /opt/lib/libicuuc.so.50
 cp /usr/lib64/libicudata.so.50.1.2 /opt/lib/libicudata.so.50
 cp /usr/lib64/libicuio.so.50.1.2 /opt/lib/libicuio.so.50
 
-# Disabled until we have a good bootstrap
-#cp /export/bootstrap /opt/
+cp /export/bootstrap /opt/
 cp /export/php.ini /opt/
 
 # Package /opt into a zip and make the zip available to the host

--- a/src/Runtime/Invocation.php
+++ b/src/Runtime/Invocation.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Runtime;
+
+/**
+ * Represents a Lambda invocation.
+ */
+class Invocation
+{
+    /** @var LambdaRuntime */
+    private $runtime;
+
+    /** @var string */
+    private $id;
+
+    /** @var array */
+    private $event;
+
+    public function __construct(LambdaRuntime $runtime, string $id, array $event)
+    {
+        $this->runtime = $runtime;
+        $this->id = $id;
+        $this->event = $event;
+    }
+
+    /**
+     * Event data sent by the invoker.
+     */
+    public function getEvent(): array
+    {
+        return $this->event;
+    }
+
+    /**
+     * Call this when the invocation has succeeded.
+     */
+    public function success($responseData = null): void
+    {
+        $this->runtime->sendResponse($this->id, $responseData);
+    }
+
+    /**
+     * Call this when the invocation has failed because of an unrecoverable error.
+     */
+    public function failure(\Throwable $error): void
+    {
+        $this->runtime->signalFailure($this->id, $error);
+    }
+}

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -1,0 +1,134 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Runtime;
+
+/**
+ * Client for the AWS Lambda runtime API.
+ *
+ * This allows to interact with the API and:
+ *
+ * - fetch events to process
+ * - signal errors
+ * - send invocation responses
+ *
+ * It is intentionally dependency-free to keep cold starts as low as possible.
+ *
+ * Usage example:
+ *
+ *     $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
+ *     $invocation = $lambdaRuntime->waitNextInvocation();
+ *     $event = $invocation->getEvent();
+ *     // [...] process the event
+ *     $invocation->success($responseData);
+ */
+class LambdaRuntime
+{
+    /** @var string */
+    private $apiUrl;
+
+    public static function fromEnvironmentVariable(): self
+    {
+        return new self(getenv('AWS_LAMBDA_RUNTIME_API'));
+    }
+
+    public function __construct(string $apiUrl)
+    {
+        $this->apiUrl = $apiUrl;
+    }
+
+    /**
+     * Wait for the next lambda invocation and retrieve its data.
+     *
+     * This call is blocking because the Lambda runtime API is blocking.
+     *
+     * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-next
+     */
+    public function waitNextInvocation(): Invocation
+    {
+        $handler = curl_init("http://{$this->apiUrl}/2018-06-01/runtime/invocation/next");
+        curl_setopt($handler, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($handler, CURLOPT_FAILONERROR, true);
+
+        // Retrieve invocation ID
+        $invocationId = '';
+        curl_setopt($handler, CURLOPT_HEADERFUNCTION, function ($ch, $header) use (&$invocationId) {
+            if (! preg_match('/:\s*/', $header)) {
+                return strlen($header);
+            }
+            [$name, $value] = preg_split('/:\s*/', $header, 2);
+            if (strtolower($name) == 'lambda-runtime-aws-request-id') {
+                $invocationId = trim($value);
+            }
+
+            return strlen($header);
+        });
+
+        // Retrieve body
+        $body = '';
+        curl_setopt($handler, CURLOPT_WRITEFUNCTION, function ($ch, $chunk) use (&$body) {
+            $body .= $chunk;
+
+            return strlen($chunk);
+        });
+
+        curl_exec($handler);
+        if (curl_error($handler)) {
+            throw new \Exception('Failed to fetch next Lambda invocation: ' . curl_error($handler));
+        }
+        if ($invocationId === '') {
+            throw new \Exception('Failed to determine the Lambda invocation ID');
+        }
+        if ($body === '') {
+            throw new \Exception('Empty Lambda runtime API response');
+        }
+        curl_close($handler);
+
+        $event = json_decode($body, true);
+
+        return new Invocation($this, $invocationId, $event);
+    }
+
+    /**
+     * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-response
+     */
+    public function sendResponse(string $invocationId, $responseData)
+    {
+        $url = "http://{$this->apiUrl}/2018-06-01/runtime/invocation/$invocationId/response";
+        $this->postJson($url, $responseData);
+    }
+
+    /**
+     * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-invokeerror
+     */
+    public function signalFailure(string $invocationId, \Throwable $error): void
+    {
+        $url = "http://{$this->apiUrl}/2018-06-01/runtime/invocation/$invocationId/error";
+        $this->postJson($url, [
+            'errorMessage' => $error->getMessage(),
+            'errorType' => get_class($error),
+        ]);
+    }
+
+    private function postJson(string $url, $data): void
+    {
+        $jsonData = json_encode($data);
+        if ($jsonData === false) {
+            throw new \Exception('Failed encoding Lambda JSON response: ' . json_last_error_msg());
+        }
+
+        $handler = curl_init($url);
+        curl_setopt($handler, CURLOPT_CUSTOMREQUEST, 'POST');
+        curl_setopt($handler, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($handler, CURLOPT_POSTFIELDS, $jsonData);
+        curl_setopt($handler, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'Content-Length: ' . strlen($jsonData),
+        ]);
+        curl_exec($handler);
+        if (curl_error($handler)) {
+            $errorMessage = curl_error($handler);
+            throw new \Exception('Error while calling the Lambda runtime API: ' . $errorMessage);
+        }
+        curl_close($handler);
+    }
+}


### PR DESCRIPTION
This PR adds an API client to interact with the new internal Lambda "runtime API".

This client will be used by Bref to receive events and send responses.

I kept curl calls to avoid introducing dependencies if not necessary. This piece of code will be called for every event, avoiding dependencies means:

- less dependencies for Bref users
- shorter cold starts (less classes to load)

Since this is simple and readable I think it's fine (even though I hate curl's API).

The next step for this is rewriting all the internals of Bref to use this instead of the old Javascript-based hack. 💪 

Also I did not add tests for this class. I plan on creating functional tests at the end. I'm still on the fence about this…