### PR TITLE
Remove the `λ` function because it duplicated the `lambda` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,23 +53,11 @@ The `init` command will create the required files, including a `bref.php` file w
 
 require __DIR__.'/vendor/autoload.php';
 
-λ(function (array $event) {
+lambda(function (array $event) {
     return [
         'hello' => $event['name'] ?? 'world',
     ];
 });
-```
-
-Note that the `λ` function is just a simple function (with a funny name) that boots Bref and runs it, here is the equivalent code without that shortcut function:
-
-```php
-$app = new \Bref\Application;
-$app->simpleHandler(function (array $event) {
-    return [
-        'hello' => $event['name'] ?? 'world',
-    ];
-});
-$app->run();
 ```
 
 For now our lambda is a simple lambda that can be invoked manually. Creating HTTP applications is covered below in the documentation.

--- a/demo/cli.php
+++ b/demo/cli.php
@@ -4,7 +4,7 @@ require __DIR__.'/../vendor/autoload.php';
 
 ini_set('display_errors', '1');
 
-λ(function (array $event) {
+lambda(function (array $event) {
     return [
         'hello' => $event['name'] ?? 'world',
     ];

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -39,6 +39,17 @@ class LambdaRuntime
         $this->apiUrl = $apiUrl;
     }
 
+    /**
+     * Process the next event.
+     *
+     * @param callable $handler This callable takes a $event parameter (array) and must return anything serializable to JSON.
+     *
+     * Example:
+     *
+     *     $lambdaRuntime->processNextEvent(function (array $event) {
+     *         return 'Hello ' . $event['name'];
+     *     });
+     */
     public function processNextEvent(callable $handler): void
     {
         [$invocationId, $event] = $this->waitNextInvocation();

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,24 +1,18 @@
 <?php declare(strict_types=1);
 
-use Bref\Runtime\LambdaRuntime;
-
 /**
- * Shortcut for creating and running a simple lambda application.
+ * Define and run a simple lambda function.
  *
  * @param callable $handler This callable takes a $event parameter (array) and must return anything serializable to JSON.
- */
-function λ(callable $handler): void
-{
-    lambda($handler);
-}
-
-/**
- * Create and run a simple lambda application.
  *
- * @param callable $handler This callable takes a $event parameter (array) and must return anything serializable to JSON.
+ * Example:
+ *
+ *     lambda(function (array $event) {
+ *         return 'Hello ' . $event['name'];
+ *     });
  */
 function lambda(callable $handler): void
 {
-    $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
+    $lambdaRuntime = Bref\Runtime\LambdaRuntime::fromEnvironmentVariable();
     $lambdaRuntime->processNextEvent($handler);
 }


### PR DESCRIPTION
Having two ways to do one thing is confusing. It's better to remove the choice to make everything more straightforward.

Also typing `λ` from scratch was impossible. I love the little fun touch but I don't think it's worth it anymore.