### PR TITLE
Documentation: add a "First steps" guide and links to next/previous articles

### DIFF
--- a/couscous.yml
+++ b/couscous.yml
@@ -27,6 +27,9 @@ menu:
             installation:
                 text: Installation
                 url: /docs/installation.html
+            first-steps:
+                text: First steps
+                url: /docs/first-steps.html
     -   section: Runtimes
         items:
             runtimes-introduction:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,10 @@
 ---
 title: What is Bref and serverless?
 currentMenu: what-is-bref
+introduction: An introduction to what serverless and Bref can offer for PHP applications.
+next:
+    link: /docs/installation.html
+    title: Installation
 ---
 
 <p class="text-lg">

--- a/docs/first-steps.md
+++ b/docs/first-steps.md
@@ -1,0 +1,66 @@
+---
+title: First steps
+currentMenu: first-steps
+introduction: First steps to discover Bref and deploy your first PHP function on AWS Lambda.
+previous:
+    link: /docs/installation.html
+    title: Installation
+next:
+    link: /docs/runtimes/
+    title: What are runtimes?
+---
+
+This guide will help you deploy your first PHP function on AWS Lambda.
+
+Before getting started make sure you have [installed Bref and the required tools](installation.md) first.
+
+## Initializing the project
+
+Starting in an empty directory, install Bref using Composer:
+
+```
+composer require mnapoli/bref:0.3.x-dev
+```
+
+Then let's start by initializing the project by running:
+
+```
+vendor/bin/bref init
+```
+
+Accept all the defaults by pressing "Enter" for each question. Congratulations, you have just created your first [PHP function](/docs/runtimes/function.md).
+
+> If you are not too familiar with AWS Lambda you need to understand that a "function" is the simplest form of code that can be deployed on AWS Lambda. It is **not** a web application: it must be invoked via AWS tools.
+>
+> You will read in the next guides how to deploy web applications using the [HTTP runtime](/docs/runtimes/http.md). We want to start with something simpler right now!
+
+The following files have been created in your project:
+
+- `index.php` contains the function code
+- `template.yaml` contains the AWS SAM configuration for deploying on AWS
+
+## Editing the code
+
+You are free to edit the code in `index.php`, you must however keep the call to the `lambda()` function:
+
+```php
+require __DIR__.'/vendor/autoload.php';
+
+lambda(function (array $event) {
+    // Do anything you want here
+    // For example:
+    return 'Hello ' . ($event['name'] ?? 'world');
+});
+```
+
+The `lambda()` function is the internal Bref function that makes sure your code is executed whenever the lambda is invoked.
+
+You can use classes and functions as well: Composer and its autoloader will work just like any PHP application.
+
+## Deployment
+
+To learn how to deploy your first function head over the [Deployment guide](deploy.md).
+
+## What's next?
+
+Now that you have deployed a simple PHP function you can [learn more about runtimes](/docs/runtimes/). That will help you deploy HTTP and console applications.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,13 @@
 ---
 title: Installation
 currentMenu: installation
+introduction: How to install Bref and the required tools.
+previous:
+    link: /docs/
+    title: What is Bref and serverless?
+next:
+    link: /docs/first-steps.html
+    title: First steps
 ---
 
 To set up Bref correctly please complete all the sections below.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,7 +35,11 @@ Alternatively the region can be overridden on every SAM command by setting the `
 Install Bref in your project using [Composer](https://getcomposer.org/):
 
 ```
-composer require mnapoli/bref
+composer require mnapoli/bref:0.3.x-dev
 ```
 
 The `bref` command line tool can now be used by running `vendor/bin/bref` in your project.
+
+## What's next?
+
+Read the [first steps](/docs/runtimes/function.md) guide to create and deploy your first serverless application using Bref.

--- a/docs/runtimes/README.md
+++ b/docs/runtimes/README.md
@@ -2,6 +2,12 @@
 title: Runtimes
 currentMenu: runtimes-introduction
 introduction: Bref provides runtimes to bring support for PHP on AWS Lambda.
+previous:
+    link: /docs/first-steps.html
+    title: First steps
+next:
+    link: /docs/runtimes/function.html
+    title: PHP functions
 ---
 
 There is no built-in support for PHP on AWS Lambda. Instead we need to use 3rd party runtimes via the system of Lambda *layers*.

--- a/docs/runtimes/console.md
+++ b/docs/runtimes/console.md
@@ -2,6 +2,9 @@
 title: Console applications
 currentMenu: console-applications
 introduction: Learn how to run serverless console commands on AWS Lambda with Symfony Console or Laravel Artisan.
+previous:
+    link: /docs/runtimes/http.html
+    title: HTTP applications
 ---
 
 Bref provides a way to run console commands on AWS Lambda.

--- a/docs/runtimes/function.md
+++ b/docs/runtimes/function.md
@@ -2,6 +2,12 @@
 title: PHP functions
 currentMenu: php-functions
 introduction: Learn how to run serverless PHP functions on AWS Lambda using Bref.
+previous:
+    link: /docs/runtimes/
+    title: What are runtimes?
+next:
+    link: /docs/runtimes/http.html
+    title: HTTP applications
 ---
 
 The simplest way to write a lambda is to write one in the form of a PHP function:

--- a/docs/runtimes/http.md
+++ b/docs/runtimes/http.md
@@ -2,6 +2,12 @@
 title: HTTP applications
 currentMenu: http-applications
 introduction: Learn how to run serverless HTTP applications with PHP on AWS Lambda using Bref.
+previous:
+    link: /docs/runtimes/function.html
+    title: PHP functions
+next:
+    link: /docs/runtimes/console.html
+    title: Console applications
 ---
 
 Bref uses PHP-FPM to run HTTP applications on AWS Lambda, just like any PHP hosting solution.

--- a/website/template/default.twig
+++ b/website/template/default.twig
@@ -50,6 +50,23 @@
                         {% block article %}
                             {{ content|raw }}
                         {% endblock %}
+
+                        {% if next is defined or previous is defined %}
+                            <div class="mt-12 mb-12 clearfix">
+                                {% if previous is defined %}
+                                    <a class="float-left mt-3" href="{{ previous.link }}" title="{{ previous.title|e('html_attr') }}">
+                                        &#9664;
+                                        Previous: {{ previous.title }}
+                                    </a>
+                                {% endif %}
+                                {% if next is defined %}
+                                    <a class="float-right mt-3" href="{{ next.link }}" title="{{ next.title|e('html_attr') }}">
+                                        Next: {{ next.title }}
+                                        &#9654;
+                                    </a>
+                                {% endif %}
+                            </div>
+                        {% endif %}
                     </article>
                 {% endblock %}
             </div>


### PR DESCRIPTION
The new "First steps" guide helps getting started with a simple PHP function after having installed Bref.

I think this is better to have this because it serves as a transition before getting started in all the articles, the runtimes, etc. Now there's a simple guide to follow to discover Bref from scratch.

This is based on feedback I got from proofreaders.