### PR TITLE
Disable compiling php-cgi

### DIFF
--- a/runtime/experimental/php.Dockerfile
+++ b/runtime/experimental/php.Dockerfile
@@ -361,7 +361,7 @@ RUN set -xe \
         --with-config-file-path=${INSTALL_DIR}/etc/php \
         --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/config.d:/var/task/php/config.d \
         --enable-fpm \
-        --enable-cgi \
+        --disable-cgi \
         --enable-cli \
         --disable-phpdbg \
         --disable-phpdbg-webhelper \


### PR DESCRIPTION
@bubba-h57 since we remove php-cgi when exporting I figured we might as well not build it?