### PR TITLE
Make sure that the status code header is not returned in the response

### DIFF
--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -89,8 +89,14 @@ class PhpFpm
 
         $responseHeaders = array_change_key_case($responseHeaders, CASE_LOWER);
 
-        $responseHeaders['status'] = $responseHeaders['status'] ?? '200 Ok';
-        [$status] = explode(' ', $responseHeaders['status']);
+        // Extract the status code
+        if (isset($responseHeaders['status'])) {
+            [$status] = explode(' ', $responseHeaders['status']);
+        } else {
+            $status = 200;
+        }
+        unset($responseHeaders['status']);
+
         $responseBody = $this->client->getResponseContent();
 
         return new LambdaResponse((int) $status, $responseHeaders, $responseBody);

--- a/tests/Runtime/PhpFpm/response-headers.php
+++ b/tests/Runtime/PhpFpm/response-headers.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+header('Content-Type: application/json');
+
+echo json_encode([
+    'data' => 'Hello world!',
+]);

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -603,6 +603,19 @@ Year,Make,Model
         return [[200], [301], [302], [400], [401], [403], [404], [500], [504]];
     }
 
+    public function test response with headers()
+    {
+        $response = $this->get('response-headers.php', [
+            'httpMethod' => 'GET',
+        ])->toApiGatewayFormat();
+
+        self::assertStringStartsWith('PHP/', $response['headers']['x-powered-by'] ?? '');
+        unset($response['headers']['x-powered-by']);
+        self::assertEquals([
+            'content-type' => 'application/json',
+        ], $response['headers']);
+    }
+
     public function test response with cookies()
     {
         $cookieHeader = $this->get('cookies.php')->toApiGatewayFormat()['headers']['set-cookie'];


### PR DESCRIPTION
This breaks the cloudfront integration because API Gateway returns 2 `status` headers (the one added by the PHP script and the one added by API Gateway automatically).

Fixes #176 