### PR TITLE
Automatically set the Content-Length header on POST requests

### DIFF
--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -178,6 +178,11 @@ class PhpFpm
         if (isset($headers['content-type'])) {
             $requestHeaders['CONTENT_TYPE'] = $headers['content-type'];
         }
+        // Auto-add the Content-Length header if it wasn't provided
+        // See https://github.com/mnapoli/bref/issues/162
+        if ((strtoupper($event['httpMethod']) === 'POST') && ! isset($headers['content-length'])) {
+            $headers['content-length'] = mb_strlen($requestBody);
+        }
         if (isset($headers['content-length'])) {
             $requestHeaders['CONTENT_LENGTH'] = $headers['content-length'];
         }

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -181,7 +181,7 @@ class PhpFpm
         // Auto-add the Content-Length header if it wasn't provided
         // See https://github.com/mnapoli/bref/issues/162
         if ((strtoupper($event['httpMethod']) === 'POST') && ! isset($headers['content-length'])) {
-            $headers['content-length'] = mb_strlen($requestBody);
+            $headers['content-length'] = strlen($requestBody);
         }
         if (isset($headers['content-length'])) {
             $requestHeaders['CONTENT_LENGTH'] = $headers['content-length'];

--- a/tests/Runtime/PhpFpm/request.php
+++ b/tests/Runtime/PhpFpm/request.php
@@ -17,4 +17,4 @@ echo json_encode([
     '$_REQUEST' => $_REQUEST,
     '$_SERVER' => $_SERVER,
     'HTTP_RAW_BODY' => file_get_contents('php://input'),
-]);
+], JSON_PRETTY_PRINT);

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -240,6 +240,38 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
+    public function test POST request supports utf8 characters in body()
+    {
+        $event = [
+            'httpMethod' => 'POST',
+            'headers' => [
+                'Content-Type' => 'text/plain; charset=UTF-8',
+                // The Content-Length header is purposefully omitted
+            ],
+            // Use a multibyte string
+            'body' => 'Hello 🌍',
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [],
+            '$_SERVER' => [
+                'CONTENT_LENGTH' => '10',
+                'CONTENT_TYPE' => 'text/plain; charset=UTF-8',
+                'REQUEST_URI' => '/',
+                'PHP_SELF' => '/',
+                'PATH_INFO' => '/',
+                'REQUEST_METHOD' => 'POST',
+                'QUERY_STRING' => '',
+                'HTTP_CONTENT_TYPE' => 'text/plain; charset=UTF-8',
+                'HTTP_CONTENT_LENGTH' => '10',
+            ],
+            'HTTP_RAW_BODY' => 'Hello 🌍',
+        ]);
+    }
+
     public function test the content type header is not case sensitive()
     {
         $event = [

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -206,6 +206,40 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
+    /**
+     * @see https://github.com/mnapoli/bref/issues/162
+     */
+    public function test POST request with body and no content length()
+    {
+        $event = [
+            'httpMethod' => 'POST',
+            'headers' => [
+                'Content-Type' => 'application/json',
+                // The Content-Length header is purposefully omitted
+            ],
+            'body' => json_encode('Hello world!'),
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [],
+            '$_SERVER' => [
+                'CONTENT_LENGTH' => '14',
+                'CONTENT_TYPE' => 'application/json',
+                'REQUEST_URI' => '/',
+                'PHP_SELF' => '/',
+                'PATH_INFO' => '/',
+                'REQUEST_METHOD' => 'POST',
+                'QUERY_STRING' => '',
+                'HTTP_CONTENT_TYPE' => 'application/json',
+                'HTTP_CONTENT_LENGTH' => '14',
+            ],
+            'HTTP_RAW_BODY' => '"Hello world!"',
+        ]);
+    }
+
     public function test the content type header is not case sensitive()
     {
         $event = [


### PR DESCRIPTION
When a POST request is made without a Content-Length header the content of the request body is dropped by PHP-FPM.

This auto-adds the header when it's not set in POST requests.

Fixes #162