### PR TITLE
#184 Log to CloudWatch in PHP-FPM by logging to stderr

### DIFF
--- a/docs/environment/logs.md
+++ b/docs/environment/logs.md
@@ -16,10 +16,23 @@ Because of that application logs should not be stored on disk.
 
 The simplest solution is to push logs to AWS CloudWatch, AWS' service for logs.
 
+### Writing logs
+
 To send logs to CloudWatch:
 
 - in a [PHP function](/docs/runtimes/function.md): write logs to `stdout` (using `echo` for example) or `stderr`
-- in a [HTTP](/docs/runtimes/http.md) or [console application](/docs/runtimes/console.md): TODO
+- in a [HTTP](/docs/runtimes/http.md): write logs to `stderr`
+
+For example with [Monolog](https://github.com/Seldaek/monolog):
+
+```php
+$log = new Logger('name');
+$log->pushHandler(new StreamHandler('php://stderr', Logger::WARNING));
+
+$log->warning('This is a warning!');
+```
+
+### Reading logs
 
 To read logs, either open the [CloudWatch console](https://us-east-1.console.aws.amazon.com/cloudwatch/home) or use SAM in the CLI:
 

--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -45,7 +45,17 @@ public function getLogDir()
 }
 ```
 
-The best solution however is not to write log on disks because those are lost. You should use a remote log collector (ELK stack) or a cloud solution like Cloudtrail, Papertrail, or Loggly.
+The best solution however is to configure Symfony to [not write logs on disk](/docs/environment/logs.md). To send logs to CloudWatch you can configure Monolog to write logs to `stderr`:
+
+```yaml
+# config/packages/prod/monolog.yaml
+monolog:
+    handlers:
+        # ...
+        nested:
+            type: stream
+            path: "php://stderr"
+```
 
 You should also set the application's cache directory to `/tmp/cache` in the same manner as described for the logs directory in the `Kernel` class.
 

--- a/runtime/php/layers/fpm/php-fpm.conf
+++ b/runtime/php/layers/fpm/php-fpm.conf
@@ -1,5 +1,7 @@
 ; Logging anywhere on disk doesn't make sense on lambda since instances are ephemeral
-error_log = /tmp/.bref/php-fpm.log
+error_log = /dev/null
+; Log above warning because PHP-FPM logs useless notices
+log_level = 'warning'
 
 [default]
 pm = static
@@ -8,3 +10,8 @@ pm.max_children = 1
 listen = /tmp/.bref/php-fpm.sock
 ; Allows PHP processes to access the lambda's environment variables
 clear_env = no
+; Forward stderr of PHP processes to stderr of PHP-FPM (so that it can be sent to cloudwatch)
+catch_workers_output = yes
+; New PHP 7.3 option that disables a verbose log prefix
+; Disabled for now until we switch to PHP 7.3
+;decorate_workers_output = no

--- a/runtime/php/layers/fpm/php.ini
+++ b/runtime/php/layers/fpm/php.ini
@@ -1,4 +1,6 @@
-display_errors=On
+; Do not display errors in production because with PHP-FPM that means
+; errors will be output in the HTTP response
+display_errors=0
 
 opcache.enable=1
 

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -52,13 +52,15 @@ class PhpFpm
             mkdir(dirname(self::SOCKET));
         }
 
-        $this->fpm = new Process(['php-fpm', '--nodaemonize', '--fpm-config', $this->configFile]);
+        /**
+         * --nodaemonize: we want to keep control of the process
+         * --force-stderr: force logs to be sent to stderr, which will allow us to send them to CloudWatch
+         */
+        $this->fpm = new Process(['php-fpm', '--nodaemonize', '--force-stderr', '--fpm-config', $this->configFile]);
         $this->fpm->setTimeout(null);
         $this->fpm->start(function ($type, $output): void {
-            if ($type === Process::ERR) {
-                echo $output;
-                exit(1);
-            }
+            // Send any PHP-FPM log to CloudWatch
+            echo $output;
         });
 
         $this->waitForServerReady();

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Resources:
             Handler: demo/http.php
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-2:416566615250:layer:php-72-fpm:4'
+                - 'arn:aws:lambda:us-east-2:416566615250:layer:php-72-fpm:8'
             Events:
                 HttpRoot:
                     Type: Api


### PR DESCRIPTION
Fix #184

It is now possible to send logs to CloudWatch from PHP when running in PHP-FPM. To do that logs must be written to `stderr`.

For example with [Monolog](https://github.com/Seldaek/monolog):

 ```php
$log = new Logger('name');
$log->pushHandler(new StreamHandler('php://stderr', Logger::WARNING));

$log->warning('This is a warning!');
```

Caveats: the log line is formatted with a prefix (from PHP-FPM). For example:

```
[19-Jan-2019 20:52:38] WARNING: [pool default] child 14 said into stderr: "My log"
```

With PHP 7.3 this will be removed (see #184), I consider it viable in the meantime as it seems to be the most sensible solution given the Lambda environment (impossible to log into a file).