### PR TITLE
Build PHP 7.3 runtimes

### DIFF
--- a/docs/runtimes/README.md
+++ b/docs/runtimes/README.md
@@ -24,32 +24,26 @@ The name of the runtimes follow this pattern:
 arn:aws:lambda:<region>:416566615250:layer:<layer-name>:<layer-version>
 ```
 
-### Supported regions (`<region>`)
+### Region (`<region>`)
 
-- `us-east-2`
-- other regions will be supported soon
+The `<region>` placeholder should contain your application's region. **You need to use the same region as the rest of your application** else Lambda will not find the layer.
 
-Remember to use the `<region>` that matches your application, else Lambda will not find the layer.
+### Runtime (`<layer-name>`)
 
-### Runtimes (`<layer-name>`)
-
-- `php-72`: contains the PHP binary, for [non-HTTP applications](/docs/runtimes/function.md)
-- `php-72-fpm`: contains PHP-FPM for [HTTP applications](/docs/runtimes/http.md)
+- `php-73`/`php-72`: contains the PHP binary, for [non-HTTP applications](/docs/runtimes/function.md)
+- `php-73-fpm`/`php-72-fpm`: contains PHP-FPM for [HTTP applications](/docs/runtimes/http.md)
 - `console`: layer that should be used on top of `php-72` to run [console commands](/docs/runtimes/console.md)
 - `php-72-loop`: experimental mode, not documented yet
 
-> `php-72` means PHP 7.2.*. Other versions like PHP 7.3 will be added soon.
+Bref currently provides runtimes for PHP 7.2 and 7.3.
 
-### Layer versions
+> `php-73` means PHP 7.3.\*. It is not possible to require a specific "patch" version.
 
-<iframe src="https://runtimes.bref.sh/embedded" class="w-full h-64"></iframe>
+### Layer version (`<layer-version>`)
 
-The list of runtime versions is available in its own website at [runtimes.bref.sh](https://runtimes.bref.sh/).
+The list of runtime versions is hosted at [runtimes.bref.sh](https://runtimes.bref.sh/) and is shown below:
 
-### Examples
-
-- `arn:aws:lambda:us-east-2:416566615250:layer:php-72:9`
-- `arn:aws:lambda:us-east-2:416566615250:layer:php-72-fpm:4`
+<iframe src="https://runtimes.bref.sh/embedded" class="w-full h-96"></iframe>
 
 ## Usage
 

--- a/docs/runtimes/console.md
+++ b/docs/runtimes/console.md
@@ -33,7 +33,7 @@ Resources:
             Runtime: provided
             Layers:
                 # PHP runtime
-                - 'arn:aws:lambda:<region>:416566615250:layer:php-72:<version>'
+                - 'arn:aws:lambda:<region>:416566615250:layer:php-73:<version>'
                 # Console layer
                 - 'arn:aws:lambda:<region>:416566615250:layer:console:<version>'
 ```

--- a/docs/runtimes/function.md
+++ b/docs/runtimes/function.md
@@ -67,7 +67,7 @@ Resources:
             Handler: index.php # the name of your PHP file
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:<region>:416566615250:layer:php-72:<version>'
+                - 'arn:aws:lambda:<region>:416566615250:layer:php-73:<version>'
 ```
 
 The runtime to use is `php`. To learn more check out [the runtimes documentation](/docs/runtimes/README.md).

--- a/docs/runtimes/http.md
+++ b/docs/runtimes/http.md
@@ -26,7 +26,7 @@ Resources:
             Handler: public/index.php
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:<region>:416566615250:layer:php-72-fpm:<version>'
+                - 'arn:aws:lambda:<region>:416566615250:layer:php-73-fpm:<version>'
             # This section contains the URL routing configuration of API Gateway
             Events:
                 HttpRoot:
@@ -61,7 +61,7 @@ Resources:
 
 ## Runtime
 
-The runtime (aka layer) is different than with [PHP functions](function.md). Instead of `php-72` it should be `php-72-fpm` because we are using PHP-FPM.
+The runtime (aka layer) is different than with [PHP functions](function.md). Instead of `php-73` it should be `php-73-fpm` because we are using PHP-FPM.
 
 ```yaml
 Resources:
@@ -69,7 +69,7 @@ Resources:
         Properties:
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:<region>:416566615250:layer:php-72-fpm:<version>'
+                - 'arn:aws:lambda:<region>:416566615250:layer:php-73-fpm:<version>'
 ```
 
 To learn more check out [the runtimes documentation](/docs/runtimes/README.md).

--- a/runtime/php/Makefile
+++ b/runtime/php/Makefile
@@ -1,19 +1,29 @@
 SHELL := /bin/bash
 
 # Build the docker container that will be used to compile PHP and its extensions
-compiler:
+compiler: compiler.Dockerfile
 	docker build -f ${PWD}/compiler.Dockerfile -t bref/runtime/compiler:latest .
 
 # Compile PHP and its extensions
 build: compiler
-	docker build -f ${PWD}/php.Dockerfile -t bref/runtime/php:latest $(shell helpers/docker_args.php php72) .
+	docker build -f ${PWD}/php.Dockerfile -t bref/runtime/php-72:latest $(shell helpers/docker_args.php php72) .
+	docker build -f ${PWD}/php.Dockerfile -t bref/runtime/php-73:latest $(shell helpers/docker_args.php php73) .
 
 # Export the compiled PHP artifacts into zip files that can be uploaded as Lambda layers
 distribution: build
-	# Run the export script in the PHP container
+	# Run the export script for PHP 7.2
 	docker run --rm \
+		--env PHP_SHORT_VERSION=72 \
 		--volume ${PWD}/layers:/layers:ro \
 		--volume ${PWD}/../export:/export \
 		--volume ${PWD}/export.sh:/export.sh:ro \
-		bref/runtime/php:latest \
+		bref/runtime/php-72:latest \
+		/export.sh
+	# Run the export script for PHP 7.3
+	docker run --rm \
+		--env PHP_SHORT_VERSION=73 \
+		--volume ${PWD}/layers:/layers:ro \
+		--volume ${PWD}/../export:/export \
+		--volume ${PWD}/export.sh:/export.sh:ro \
+		bref/runtime/php-73:latest \
 		/export.sh

--- a/runtime/php/export.sh
+++ b/runtime/php/export.sh
@@ -7,8 +7,6 @@ set -u
 # Print all commands before executing them
 set -x
 
-export PHP_ZIP_NAME='/export/php-72'
-
 cd /opt
 
 # We do not support running pear functions in Lambda
@@ -32,9 +30,9 @@ cp /layers/function/bootstrap bootstrap
 chmod 755 bootstrap
 cp /layers/function/php.ini bref/etc/php/php.ini
 # Zip the layer
-zip --quiet --recurse-paths ${PHP_ZIP_NAME}.zip . --exclude "*php-cgi"
+zip --quiet --recurse-paths /export/php-${PHP_SHORT_VERSION}.zip . --exclude "*php-cgi"
 # Remove PHP-FPM from this layer
-zip --delete ${PHP_ZIP_NAME}.zip bref/sbin/php-fpm bin/php-fpm
+zip --delete /export/php-${PHP_SHORT_VERSION}.zip bref/sbin/php-fpm bin/php-fpm
 # Cleanup the files specific to this layer
 rm bootstrap
 rm bref/etc/php/php.ini
@@ -46,7 +44,7 @@ chmod 755 bootstrap
 cp /layers/fpm/php.ini bref/etc/php/php.ini
 cp /layers/fpm/php-fpm.conf bref/etc/php-fpm.conf
 # Zip the layer
-zip --quiet --recurse-paths ${PHP_ZIP_NAME}-fpm.zip . --exclude "*php-cgi"
+zip --quiet --recurse-paths /export/php-${PHP_SHORT_VERSION}-fpm.zip . --exclude "*php-cgi"
 # Cleanup the files specific to this layer
 rm bootstrap
 rm bref/etc/php/php.ini

--- a/runtime/php/php.Dockerfile
+++ b/runtime/php/php.Dockerfile
@@ -381,12 +381,13 @@ RUN set -xe \
         --with-pdo-pgsql=shared,${INSTALL_DIR} \
         --enable-intl=shared \
         --enable-opcache-file
-RUN set -xe \
- && make -j $(nproc) \
- && make install \
- && { find =${INSTALL_DIR}/bin =${INSTALL_DIR}/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
- && make clean \
- && cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
+RUN make -j $(nproc)
+# Run `make install` and override PEAR's PHAR URL because pear.php.net is down
+RUN set -xe; \
+ make install PEAR_INSTALLER_URL='https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar'; \
+ { find ${INSTALL_DIR}/bin ${INSTALL_DIR}/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; }; \
+ make clean; \
+ cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
 
 RUN pecl install mongodb
 RUN pecl install redis

--- a/runtime/php/php.Dockerfile
+++ b/runtime/php/php.Dockerfile
@@ -397,12 +397,12 @@ RUN set -xe; \
     curl -Ls https://elasticache-downloads.s3.amazonaws.com/ClusterClient/PHP-7.0/latest-64bit \
   | tar xzC $(php-config --extension-dir) --strip-components=1
 
-ENV VERSION_PTHREADS=3.2.0
 ENV PTHREADS_BUILD_DIR=${BUILD_DIR}/pthreads
 
+# Build from master because there are no pthreads release compatible with PHP 7.3
 RUN set -xe; \
     mkdir -p ${PTHREADS_BUILD_DIR}/bin; \
-    curl -Ls https://github.com/krakjoe/pthreads/archive/v${VERSION_PTHREADS}.tar.gz \
+    curl -Ls https://github.com/krakjoe/pthreads/archive/master.tar.gz \
     | tar xzC ${PTHREADS_BUILD_DIR} --strip-components=1
 
 WORKDIR  ${PTHREADS_BUILD_DIR}/

--- a/runtime/php/versions.ini
+++ b/runtime/php/versions.ini
@@ -1,3 +1,58 @@
+[php73]
+; https://github.com/madler/zlib/releases
+; Needed for:
+;   - openssl
+;   - curl
+;   - pcre
+zlib = "1.2.11"
+
+; https://github.com/openssl/openssl/releases
+; Needs:
+;   - zlib
+; Needed by:
+;   - curl
+;   - php
+openssl = "1.1.1a"
+
+; https://github.com/GNOME/libxml2/releases
+; Needs:
+;   - zlib
+; Needed by:
+;   - php
+libxml2 = "2.9.8"
+
+; https://github.com/jedisct1/libsodium/releases
+; Needs:
+;   -
+; Needed by:
+;   - php
+libsodium = "1.0.16"
+
+; https://github.com/libssh2/libssh2/releases
+; Needs:
+;   - None
+; Needed by:
+;   - curl
+libssh2 = "1.8.0"
+
+; https://github.com/curl/curl/releases
+; Needs:
+;   - OpenSSL
+;   - zlib
+;   - libssh2
+; Needed by:
+;   - php
+curl = "7.63.0"
+
+; https://github.com/postgres/postgres/releases
+; Needs:
+;   -
+; Needed by:
+;   - php
+postgres = "9.6.11"
+
+php = "7.3.1"
+
 [php72]
 ; https://github.com/madler/zlib/releases
 ; Needed for:

--- a/runtime/publish.php
+++ b/runtime/publish.php
@@ -9,6 +9,8 @@ use Symfony\Component\Process\Process;
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $layers = [
+    'php-73' => 'PHP 7.3 for PHP functions',
+    'php-73-fpm' => 'PHP-FPM 7.3 for HTTP applications',
     'php-72' => 'PHP 7.2 for PHP functions',
     'php-72-fpm' => 'PHP-FPM 7.2 for HTTP applications',
     'console' => 'Console runtime for PHP applications',

--- a/template/console/template.yaml
+++ b/template/console/template.yaml
@@ -9,9 +9,9 @@ Resources:
             FunctionName: 'my-function'
             Description: ''
             CodeUri: .
-            Handler: app/console # Replace by `artisan` if you are using Laravel
+            Handler: bin/console # Replace by `artisan` if you are using Laravel
             Timeout: 30 # in seconds
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-2:416566615250:layer:php-72:9' # PHP
-                - 'arn:aws:lambda:us-east-2:416566615250:layer:console:1' # The "console" layer
+                - 'arn:aws:lambda:us-east-1:416566615250:layer:php-73:1' # PHP
+                - 'arn:aws:lambda:us-east-1:416566615250:layer:console:4' # The "console" layer

--- a/template/default/template.yaml
+++ b/template/default/template.yaml
@@ -13,4 +13,4 @@ Resources:
             Timeout: 10 # Timeout in seconds
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-2:416566615250:layer:php-72:9'
+                - 'arn:aws:lambda:us-east-1:416566615250:layer:php-73:1'

--- a/template/http/template.yaml
+++ b/template/http/template.yaml
@@ -13,7 +13,7 @@ Resources:
             Timeout: 30 # in seconds (API Gateway has a timeout of 30 seconds)
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-2:416566615250:layer:php-72-fpm:4'
+                - 'arn:aws:lambda:us-east-1:416566615250:layer:php-73-fpm:1'
             Events:
                 # The function will match all HTTP URLs
                 HttpRoot:

--- a/website/tailwind.js
+++ b/website/tailwind.js
@@ -573,6 +573,7 @@ module.exports = {
     '32': '8rem',
     '48': '12rem',
     '64': '16rem',
+    '96': '24rem',
     'full': '100%',
     'screen': '100vh',
   },


### PR DESCRIPTION
Following #184 I gave a try to compiling PHP 7.3 and it just worked, and it was pretty simple to re-add to the build.

If the published runtimes work correctly then let's support that version as well.