### PR TITLE
The default php.ini is incomplete

### DIFF
--- a/runtime/php/export.sh
+++ b/runtime/php/export.sh
@@ -28,7 +28,8 @@ rm -rf bref/data
 # Create the PHP CLI layer
 cp /layers/function/bootstrap bootstrap
 chmod 755 bootstrap
-cp /layers/function/php.ini bref/etc/php/php.ini
+
+cat /layers/function/php.ini >> bref/etc/php/php.ini
 # Zip the layer
 zip --quiet --recurse-paths /export/php-${PHP_SHORT_VERSION}.zip . --exclude "*php-cgi"
 # Remove PHP-FPM from this layer


### PR DESCRIPTION
Fix for Bug #191
We append now the content from our own php.ini and don't override the hole file.

