### PR TITLE
Fix #191 and how the php.ini is dealt with

### DIFF
--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -9,7 +9,7 @@ introduction: Configure PHP versions, extensions and options for your serverless
 PHP will read its configuration from:
 
 - `/opt/bref/etc/php/php.ini` (PHP's official production configuration)
-- `/opt/bref/etc/php/config.d/bref.ini` (Bref's optimizations for Lambda)
+- `/opt/bref/etc/php/conf.d/bref.ini` (Bref's optimizations for Lambda)
 
 These files *cannot be customized*.
 
@@ -32,7 +32,7 @@ Learn how to declare environment variables by reading the [Environment Variables
 
 ### Customizing php.ini in extra layers
 
-If you are using Lambda layers, for example to use custom PHP extensions, you can override the default `php.ini` by placing your own configuration file in `/opt/bref/etc/php/config.d/`.
+If you are using Lambda layers, for example to use custom PHP extensions, you can override the default `php.ini` by placing your own configuration file in `/opt/bref/etc/php/conf.d/`.
 
 Make sur to give a unique name to your `.ini` file to avoid any collision with other layers.
 

--- a/runtime/php/export.sh
+++ b/runtime/php/export.sh
@@ -12,24 +12,24 @@ cd /opt
 # Create the PHP CLI layer
 cp /layers/function/bootstrap bootstrap
 chmod 755 bootstrap
-cp /layers/function/php.ini bref/etc/php/php.ini
+cp /layers/function/php.ini bref/etc/php/conf.d/bref.ini
 # Zip the layer
 zip --quiet --recurse-paths /export/php-${PHP_SHORT_VERSION}.zip . --exclude "*php-cgi"
 # Remove PHP-FPM from this layer
 zip --delete /export/php-${PHP_SHORT_VERSION}.zip bref/sbin/php-fpm bin/php-fpm
 # Cleanup the files specific to this layer
 rm bootstrap
-rm bref/etc/php/php.ini
+rm bref/etc/php/conf.d/bref.ini
 
 # Create the PHP FPM layer
 # Add files specific to this layer
 cp /layers/fpm/bootstrap bootstrap
 chmod 755 bootstrap
-cp /layers/fpm/php.ini bref/etc/php/php.ini
+cp /layers/fpm/php.ini bref/etc/php/conf.d/bref.ini
 cp /layers/fpm/php-fpm.conf bref/etc/php-fpm.conf
 # Zip the layer
 zip --quiet --recurse-paths /export/php-${PHP_SHORT_VERSION}-fpm.zip . --exclude "*php-cgi"
 # Cleanup the files specific to this layer
 rm bootstrap
-rm bref/etc/php/php.ini
+rm bref/etc/php/conf.d/bref.ini
 rm bref/etc/php-fpm.conf

--- a/runtime/php/php.Dockerfile
+++ b/runtime/php/php.Dockerfile
@@ -31,6 +31,7 @@ RUN mkdir -p ${BUILD_DIR}  \
     ${INSTALL_DIR}/bin \
     ${INSTALL_DIR}/doc \
     ${INSTALL_DIR}/etc/php \
+    ${INSTALL_DIR}/etc/php/conf.d \
     ${INSTALL_DIR}/include \
     ${INSTALL_DIR}/lib \
     ${INSTALL_DIR}/lib64 \

--- a/runtime/php/php.Dockerfile
+++ b/runtime/php/php.Dockerfile
@@ -390,7 +390,7 @@ RUN set -xe \
         --enable-option-checking=fatal \
         --enable-maintainer-zts \
         --with-config-file-path=${INSTALL_DIR}/etc/php \
-        --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/config.d:/var/task/php/config.d \
+        --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/conf.d:/var/task/php/conf.d \
         --enable-fpm \
         --disable-cgi \
         --enable-cli \

--- a/tests/Sam/PhpFpmRuntimeTest.php
+++ b/tests/Sam/PhpFpmRuntimeTest.php
@@ -101,8 +101,8 @@ class PhpFpmRuntimeTest extends TestCase
             'display_errors' => '0',
             // This is sent to PHP-FPM, which sends them back to CloudWatch
             'error_log' => null,
-            // Leave the default value recommended by PHP
-            'error_reporting' => null,
+            // This is the default production value
+            'error_reporting' => (string) (E_ALL & ~E_DEPRECATED & ~E_STRICT),
             'extension_dir' => '/opt/bref/lib/php/extensions/no-debug-zts-20180731',
             // Same limit as API Gateway
             'max_execution_time' => '30',
@@ -118,8 +118,8 @@ class PhpFpmRuntimeTest extends TestCase
             'opcache.save_comments' => '1',
             // The code is readonly on lambdas so it never changes
             'opcache.validate_timestamps' => '0',
-            'short_open_tag' => '1',
-            'zend.assertions' => '1',
+            'short_open_tag' => '',
+            'zend.assertions' => '-1',
             'zend.enable_gc' => '1',
         ], $config, $stderr);
     }

--- a/tests/Sam/PhpRuntimeTest.php
+++ b/tests/Sam/PhpRuntimeTest.php
@@ -95,8 +95,8 @@ class PhpRuntimeTest extends TestCase
             'display_errors' => '1',
             // This means `stderr` in php-cli (http://php.net/manual/errorfunc.configuration.php#ini.error-log)
             'error_log' => null,
-            // Leave the default value recommended by PHP
-            'error_reporting' => null,
+            // This is the default production value
+            'error_reporting' => (string) (E_ALL & ~E_DEPRECATED & ~E_STRICT),
             'extension_dir' => '/opt/bref/lib/php/extensions/no-debug-zts-20180731',
             // No need for HTML formatting on the CLI
             'html_errors' => '0',
@@ -116,8 +116,8 @@ class PhpRuntimeTest extends TestCase
             'opcache.save_comments' => '1',
             // The code is readonly on lambdas so it never changes
             'opcache.validate_timestamps' => '0',
-            'short_open_tag' => '1',
-            'zend.assertions' => '1',
+            'short_open_tag' => '',
+            'zend.assertions' => '-1',
             'zend.enable_gc' => '1',
         ], $result, $stderr);
     }

--- a/tests/Sam/template.yaml
+++ b/tests/Sam/template.yaml
@@ -10,7 +10,7 @@ Resources:
             Handler: tests/Sam/Php/function.php
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-1:416566615250:layer:php-73:4'
+                - 'arn:aws:lambda:us-east-1:416566615250:layer:php-73:5'
 
     HttpFunction:
         Type: AWS::Serverless::Function
@@ -20,7 +20,7 @@ Resources:
             Handler: tests/Sam/PhpFpm/index.php
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-1:416566615250:layer:php-73-fpm:4'
+                - 'arn:aws:lambda:us-east-1:416566615250:layer:php-73-fpm:5'
             Events:
                 HttpRoot:
                     Type: Api


### PR DESCRIPTION
- Rename `/opt/bref/etc/php/config.d/` into `/opt/bref/etc/php/conf.d/`
  This follows the existing standards in popular Linux distributions.
- Fix #191 
  Keep PHP's recommended production config instead of overwriting it