### PR TITLE
Disable logging above "warning" in PHP-FPM

### DIFF
--- a/runtime/php/layers/fpm/php-fpm.conf
+++ b/runtime/php/layers/fpm/php-fpm.conf
@@ -1,7 +1,9 @@
 ; Logging anywhere on disk doesn't make sense on lambda since instances are ephemeral
 error_log = /dev/null
 ; Log above warning because PHP-FPM logs useless notices
-log_level = 'warning'
+; We must comment this flag else uncaught exceptions/fatal errors are not reported in the logs!
+; TODO: report that to the PHP bug tracker
+;log_level = 'warning'
 
 [default]
 pm = static

--- a/tests/Runtime/PhpFpm/php-fpm.conf
+++ b/tests/Runtime/PhpFpm/php-fpm.conf
@@ -1,7 +1,7 @@
 ; Logging anywhere on disk doesn't make sense on lambda since instances are ephemeral
 error_log = /dev/null
 ; Log above warning because PHP-FPM logs useless notices
-log_level = 'warning'
+;log_level = 'warning'
 
 [default]
 pm = static


### PR DESCRIPTION
After doing some testing this flag actually removes warning logs. When enabled any uncaught exception in a PHP FPM worker will not be logged.

After removing it the logs are correct again.

Let's disable this for now.