### PR TITLE
Add tests to cover a bug where logs are forwarded in HTTP response headers

### DIFF
--- a/tests/Runtime/PhpFpm/error.php
+++ b/tests/Runtime/PhpFpm/error.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types=1);
+
+error_log('This is a test message');

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -693,9 +693,7 @@ Year,Make,Model
     {
         $headers = $this->get('error.php')->toApiGatewayFormat()['headers'];
 
-        self::assertEquals([
-            'content-type' => 'text/html; charset=UTF-8',
-        ], $headers);
+        self::assertEquals([], (array) $headers);
     }
 
     private function assertGlobalVariables(array $event, array $expectedGlobalVariables): void

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -689,6 +689,15 @@ Year,Make,Model
         self::assertEquals('MyCookie=MyValue; expires=Fri, 12-Jan-2018 08:32:03 GMT; Max-Age=0; path=/hello/; domain=example.com; secure; HttpOnly', $cookieHeader);
     }
 
+    public function test response with error_log()
+    {
+        $headers = $this->get('error.php')->toApiGatewayFormat()['headers'];
+
+        self::assertEquals([
+            'content-type' => 'text/html; charset=UTF-8',
+        ], $headers);
+    }
+
     private function assertGlobalVariables(array $event, array $expectedGlobalVariables): void
     {
         $this->startFpm(__DIR__ . '/PhpFpm/request.php');

--- a/tests/Sam/PhpFpmRuntimeTest.php
+++ b/tests/Sam/PhpFpmRuntimeTest.php
@@ -47,7 +47,7 @@ class PhpFpmRuntimeTest extends TestCase
     {
         $response = $this->invoke('/?error_log=1');
 
-        $this->assertResponseSuccessful($response);
+        self::assertSame(500, $response->getStatusCode(), $this->logs);
         self::assertNotContains('This is a test log from error_log', $this->responseAsString($response));
         self::assertContains('This is a test log from error_log', $this->logs);
     }
@@ -74,8 +74,7 @@ class PhpFpmRuntimeTest extends TestCase
     {
         $response = $this->invoke('/?fatal_error=1');
 
-        // PHP being PHP :'(
-        self::assertSame(200, $response->getStatusCode(), $this->logs);
+        self::assertSame(500, $response->getStatusCode(), $this->logs);
         self::assertNotContains("require(): Failed opening required 'foo'", $this->responseAsString($response));
         $expectedLogs = "PHP Fatal error:  require(): Failed opening required 'foo' (include_path='.:/opt/bref/lib/php') in /var/task/tests/Sam";
         self::assertContains($expectedLogs, $this->logs);
@@ -85,8 +84,10 @@ class PhpFpmRuntimeTest extends TestCase
     {
         $response = $this->invoke('/?warning=1');
 
-        $this->assertResponseSuccessful($response);
-        self::assertEquals('Hello world!', $this->getBody($response), $this->logs);
+        self::assertSame(500, $response->getStatusCode(), $this->logs);
+        // Unfortunately with the temporary fix in https://github.com/mnapoli/bref/pull/216
+        // we must settle for an empty 500 response for now
+//        self::assertEquals('Hello world!', $this->getBody($response), $this->logs);
         self::assertContains('Warning:  This is a test warning in /var/task/tests/Sam', $this->logs);
     }
 

--- a/tests/Sam/PhpFpmRuntimeTest.php
+++ b/tests/Sam/PhpFpmRuntimeTest.php
@@ -39,7 +39,7 @@ class PhpFpmRuntimeTest extends TestCase
         $response = $this->invoke('/?stderr=1');
 
         $this->assertResponseSuccessful($response);
-        self::assertNotContains('This is a test log into stderr', $this->getBody($response));
+        self::assertNotContains('This is a test log into stderr', $this->responseAsString($response));
         self::assertContains('This is a test log into stderr', $this->logs);
     }
 
@@ -48,7 +48,7 @@ class PhpFpmRuntimeTest extends TestCase
         $response = $this->invoke('/?error_log=1');
 
         $this->assertResponseSuccessful($response);
-        self::assertNotContains('This is a test log from error_log', $this->getBody($response));
+        self::assertNotContains('This is a test log from error_log', $this->responseAsString($response));
         self::assertContains('This is a test log from error_log', $this->logs);
     }
 
@@ -57,6 +57,7 @@ class PhpFpmRuntimeTest extends TestCase
         $response = $this->invoke('/?exception=1');
 
         self::assertSame(500, $response->getStatusCode(), $this->logs);
+        self::assertNotContains('This is an uncaught exception', $this->responseAsString($response));
         self::assertContains('Fatal error:  Uncaught Exception: This is an uncaught exception in /var/task/tests/Sam', $this->logs);
     }
 
@@ -65,6 +66,7 @@ class PhpFpmRuntimeTest extends TestCase
         $response = $this->invoke('/?error=1');
 
         self::assertSame(500, $response->getStatusCode(), $this->logs);
+        self::assertNotContains('strlen() expects exactly 1 parameter, 0 given', $this->responseAsString($response));
         self::assertContains('PHP Fatal error:  Uncaught ArgumentCountError: strlen() expects exactly 1 parameter, 0 given in /var/task/tests/Sam', $this->logs);
     }
 
@@ -74,6 +76,7 @@ class PhpFpmRuntimeTest extends TestCase
 
         // PHP being PHP :'(
         self::assertSame(200, $response->getStatusCode(), $this->logs);
+        self::assertNotContains("require(): Failed opening required 'foo'", $this->responseAsString($response));
         $expectedLogs = "PHP Fatal error:  require(): Failed opening required 'foo' (include_path='.:/opt/bref/lib/php') in /var/task/tests/Sam";
         self::assertContains($expectedLogs, $this->logs);
     }
@@ -206,5 +209,16 @@ class PhpFpmRuntimeTest extends TestCase
     private function getJsonBody(ResponseInterface $response)
     {
         return json_decode($response->getBody()->getContents(), true);
+    }
+
+    private function responseAsString(ResponseInterface $response): string
+    {
+        $string = '';
+        foreach ($response->getHeaders() as $name => $values) {
+            $string .= $name . ': ' . implode(', ', $values) . "\n";
+        }
+        $string .= "\n" . $this->getBody($response) . "\n";
+
+        return $string;
     }
 }


### PR DESCRIPTION
PHP-FPM sends logs in the FastCGI output under the key `PHP message:`. Those lines end up in the HTTP headers. They are parsed by Hoa/FastCGI as response headers.

In the end those logs are considered as part as the HTTP response headers but they are not.

PHP-FPM should not write those in the FastCGI connection. I cannot understand why this is happening and how to fix this.

Example of a raw HTTP response sent by PHP-FPM over FastCGI:

```
PHP Message: This is a test log from error_logX-Powered-By: PHP/7.3.1
Content-Type: text/html; charset=UTF-8
Content-Length: 12
Server: Werkzeug/0.14.1 Python/3.7.2
Date: Wed, 30 Jan 2019 21:29:43 GMT

Hello world!
```

As you can see in the first line the first HTTP header (`X-Powered-By`) is mangled with the log line.

See the tests for a scenario to reproduce it.

I tried several options (not daemonizing FPM, disabling logging in stderr, etc.) but no success.