### PR TITLE
Add PHP 7.2 notice into documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,7 @@ Install Bref in your project using [Composer](https://getcomposer.org/):
 ```
 composer require mnapoli/bref
 ```
+> Notice: For running the latest version of Bref, you must have installed PHP 7.2.
 
 The `bref` command line tool can now be used by running `vendor/bin/bref` in your project.
 


### PR DESCRIPTION
Nice to be mentioned PHP 7.2 as a must into documentation.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
