### PR TITLE
Improve copying template files using init option

### DIFF
--- a/bref
+++ b/bref
@@ -20,8 +20,8 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 
 $app = new Silly\Application('Deploy serverless PHP applications');
 
-$app->command('init [--baseTemplateDir=]', function (?string $baseTemplateDir, SymfonyStyle $io) {
-    $baseTemplateDir = $baseTemplateDir ?? __DIR__ . "/template";
+$app->command('init', function (SymfonyStyle $io) {
+    $baseTemplateDir = __DIR__ . "/template";
     $exeFinder = new ExecutableFinder();
     if (! $exeFinder->find('sam')) {
         $io->error(

--- a/bref
+++ b/bref
@@ -69,12 +69,12 @@ $app->command('init', function (SymfonyStyle $io) {
     $fs = new Filesystem;
     $rootPath = "$baseTemplateDir/$templateDirectory";
     $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($rootPath));
-    /**
-     * @var RecursiveDirectoryIterator $files
-     * @var SplFileInfo $file
-     */
     foreach ($files as $file) {
-        $fileName = $files->getSubPathname();
+        /**
+         * @var RecursiveDirectoryIterator $dir
+         */
+        $dir = $files->getInnerIterator();
+        $fileName = $dir->getSubPathname();
         $srcFile = "$baseTemplateDir/$templateDirectory/$fileName";
         if ($file->isFile() &&  $fs->exists($srcFile)) {
             $io->writeln("Creating $fileName");
@@ -87,7 +87,11 @@ $app->command('init', function (SymfonyStyle $io) {
      */
     if ((new Process(['git', 'rev-parse', '--is-inside-work-tree']))->run() === 0) {
         foreach ($files as $file) {
-            $fileName = $files->getSubPathName();
+            /**
+             * @var RecursiveDirectoryIterator $dir
+             */
+            $dir = $files->getInnerIterator();
+            $fileName = $dir->getSubPathname();
             $srcFile = "$baseTemplateDir/$templateDirectory/$fileName";
             if ($file->isFile() && $fs->exists($srcFile)) {
                 (new Process(['git', 'add', $fileName]))->run();

--- a/bref
+++ b/bref
@@ -75,7 +75,7 @@ $app->command('init', function (SymfonyStyle $io) {
          */
         $dir = $files->getInnerIterator();
         $fileName = $dir->getSubPathname();
-        $srcFile = "$baseTemplateDir/$templateDirectory/$fileName";
+        $srcFile = "$rootPath/$fileName";
         if ($file->isFile() &&  $fs->exists($srcFile)) {
             $io->writeln("Creating $fileName");
             $fs->copy($srcFile, $fileName);
@@ -92,7 +92,7 @@ $app->command('init', function (SymfonyStyle $io) {
              */
             $dir = $files->getInnerIterator();
             $fileName = $dir->getSubPathname();
-            $srcFile = "$baseTemplateDir/$templateDirectory/$fileName";
+            $srcFile = "$rootPath/$fileName";
             if ($file->isFile() && $fs->exists($srcFile)) {
                 (new Process(['git', 'add', $fileName]))->run();
             }

--- a/bref
+++ b/bref
@@ -72,7 +72,7 @@ $app->command('init [--baseTemplateDir=]', function (?string $baseTemplateDir, S
     $finder->files()->in("$baseTemplateDir/$templateDirectory");
 
     foreach ($finder as $file) {
-        $fileName = $file->getFilename();
+        $fileName = $file->getRelativePathname();
         $srcFile = "$baseTemplateDir/$templateDirectory/$fileName";
         if ($fs->exists($srcFile)) {
             $io->writeln("Creating $fileName");
@@ -85,7 +85,7 @@ $app->command('init [--baseTemplateDir=]', function (?string $baseTemplateDir, S
      */
     if ((new Process(['git', 'rev-parse', '--is-inside-work-tree']))->run() === 0) {
         foreach ($finder as $file) {
-            $fileName = $file->getFilename();
+            $fileName = $file->getRelativePathname();
             $srcFile = "$baseTemplateDir/$templateDirectory/$fileName";
             if ($fs->exists($srcFile)) {
                 (new Process(['git', 'add', $fileName]))->run();

--- a/bref
+++ b/bref
@@ -6,7 +6,6 @@ use Bref\Lambda\InvocationFailed;
 use Bref\Lambda\SimpleLambdaClient;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -68,13 +67,16 @@ $app->command('init', function (SymfonyStyle $io) {
     ][$choice];
 
     $fs = new Filesystem;
-    $finder = new Finder();
-    $finder->files()->in("$baseTemplateDir/$templateDirectory");
-
-    foreach ($finder as $file) {
-        $fileName = $file->getRelativePathname();
+    $rootPath = "$baseTemplateDir/$templateDirectory";
+    $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($rootPath));
+    /**
+     * @var RecursiveDirectoryIterator $files
+     * @var SplFileInfo $file
+     */
+    foreach ($files as $file) {
+        $fileName = $files->getSubPathname();
         $srcFile = "$baseTemplateDir/$templateDirectory/$fileName";
-        if ($fs->exists($srcFile)) {
+        if ($file->isFile() &&  $fs->exists($srcFile)) {
             $io->writeln("Creating $fileName");
             $fs->copy($srcFile, $fileName);
         }
@@ -84,10 +86,10 @@ $app->command('init', function (SymfonyStyle $io) {
      * We check if this is a git repository to automatically add files to git.
      */
     if ((new Process(['git', 'rev-parse', '--is-inside-work-tree']))->run() === 0) {
-        foreach ($finder as $file) {
-            $fileName = $file->getRelativePathname();
+        foreach ($files as $file) {
+            $fileName = $files->getSubPathName();
             $srcFile = "$baseTemplateDir/$templateDirectory/$fileName";
-            if ($fs->exists($srcFile)) {
+            if ($file->isFile() && $fs->exists($srcFile)) {
                 (new Process(['git', 'add', $fileName]))->run();
             }
         }

--- a/bref
+++ b/bref
@@ -6,6 +6,7 @@ use Bref\Lambda\InvocationFailed;
 use Bref\Lambda\SimpleLambdaClient;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -19,7 +20,8 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 
 $app = new Silly\Application('Deploy serverless PHP applications');
 
-$app->command('init', function (SymfonyStyle $io) {
+$app->command('init [--baseTemplateDir=]', function (?string $baseTemplateDir, SymfonyStyle $io) {
+    $baseTemplateDir = $baseTemplateDir ?? __DIR__ . "/template";
     $exeFinder = new ExecutableFinder();
     if (! $exeFinder->find('sam')) {
         $io->error(
@@ -66,11 +68,16 @@ $app->command('init', function (SymfonyStyle $io) {
     ][$choice];
 
     $fs = new Filesystem;
-    $io->writeln('Creating template.yaml');
-    $fs->copy(__DIR__ . "/template/$templateDirectory/template.yaml", 'template.yaml');
-    if ($fs->exists(__DIR__ . "/template/$templateDirectory/index.php")) {
-        $io->writeln('Creating index.php');
-        $fs->copy(__DIR__ . "/template/$templateDirectory/index.php", 'index.php');
+    $finder = new Finder();
+    $finder->files()->in("$baseTemplateDir/$templateDirectory");
+
+    foreach ($finder as $file) {
+        $fileName = $file->getFilename();
+        $srcFile = "$baseTemplateDir/$templateDirectory/$fileName";
+        if ($fs->exists($srcFile)) {
+            $io->writeln("Creating $fileName");
+            $fs->copy($srcFile, $fileName);
+        }
     }
 
     /*

--- a/bref
+++ b/bref
@@ -84,9 +84,12 @@ $app->command('init [--baseTemplateDir=]', function (?string $baseTemplateDir, S
      * We check if this is a git repository to automatically add files to git.
      */
     if ((new Process(['git', 'rev-parse', '--is-inside-work-tree']))->run() === 0) {
-        (new Process(['git', 'add', 'template.yaml']))->run();
-        if (file_exists('index.php')) {
-            (new Process(['git', 'add', 'index.php']))->run();
+        foreach ($finder as $file) {
+            $fileName = $file->getFilename();
+            $srcFile = "$baseTemplateDir/$templateDirectory/$fileName";
+            if ($fs->exists($srcFile)) {
+                (new Process(['git', 'add', $fileName]))->run();
+            }
         }
 
         $io->success([

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "ext-json": "*",
         "mnapoli/silly": "^1.7",
         "symfony/filesystem": "^3.1|^4.0",
+        "symfony/finder": "^3.1|^4.0",
         "symfony/http-foundation": "^3.1|^4.0",
         "symfony/process": "^3.1|^4.0",
         "symfony/psr-http-message-bridge": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "ext-json": "*",
         "mnapoli/silly": "^1.7",
         "symfony/filesystem": "^3.1|^4.0",
-        "symfony/finder": "^3.1|^4.0",
         "symfony/http-foundation": "^3.1|^4.0",
         "symfony/process": "^3.1|^4.0",
         "symfony/psr-http-message-bridge": "^1.0",


### PR DESCRIPTION
When trying to create a library layer it makes a lot of sense to be able to override the templates as one may want to init the lambda function with a custom bootstrap or template.yaml which already includes the library layer additionally.

Also it could be cumbersome in the future to maintain additional template files. So it copies all files from the specified template directory.