### PR TITLE
Allow to use Diactoros 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",
-        "zendframework/zend-diactoros": "^1.6",
+        "zendframework/zend-diactoros": "^1.6|^2.0",
         "doctrine/coding-standard": "^5.0",
         "phpstan/phpstan": "^0.10.5",
         "guzzlehttp/guzzle": "^6.3"


### PR DESCRIPTION
Update Diactoros to allow to use version 2 (currently it is not possible to install this package with latest version of Expressive due to dependency constraints).