### PR TITLE
Set the memory size to 1024M by default for new lambdas

### DIFF
--- a/template/console/template.yaml
+++ b/template/console/template.yaml
@@ -11,6 +11,7 @@ Resources:
             CodeUri: .
             Handler: bin/console # Replace by `artisan` if you are using Laravel
             Timeout: 30 # in seconds
+            MemorySize: 1024 # The memory size is related to the pricing and CPU power
             Runtime: provided
             Layers:
                 - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:1' # PHP

--- a/template/default/template.yaml
+++ b/template/default/template.yaml
@@ -11,6 +11,7 @@ Resources:
             CodeUri: .
             Handler: index.php
             Timeout: 10 # Timeout in seconds
+            MemorySize: 1024 # The memory size is related to the pricing and CPU power
             Runtime: provided
             Layers:
                 - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:1'

--- a/template/http/template.yaml
+++ b/template/http/template.yaml
@@ -11,6 +11,7 @@ Resources:
             CodeUri: .
             Handler: index.php
             Timeout: 30 # in seconds (API Gateway has a timeout of 30 seconds)
+            MemorySize: 1024 # The memory size is related to the pricing and CPU power
             Runtime: provided
             Layers:
                 - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73-fpm:1'


### PR DESCRIPTION
The amount of memory allocated to a lambda is proportional to the pricing and the CPU power allocated. The default is 128M, which is the cheapest but also the least powerful.

That is confusing to new users because it has very low performances. It is useful for scenarios where performances are not important. However with Bref we want to let users run PHP "like anywhere else", which implies HTTP scenarios. Using 128M means a 10× less powerful CPU, i.e. slow response times.

In order to avoid bad surprises to new users it's better to start with 1024M. Most test applications (or new applications) will be covered by the free tier, and unless it's a big application (in which case the user will probably dig more into this before sending in production) lambda costs are very small.

Also for the record Bref 0.2 set 1024M by default.

In the future we should have a documentation page dedicated to performances that will explain this parameter in more details.

See https://docs.aws.amazon.com/lambda/latest/dg/resource-model.html and https://aws.amazon.com/lambda/pricing/
