### PR TITLE
Introduce Event object for late success or failure

### DIFF
--- a/src/Runtime/Client.php
+++ b/src/Runtime/Client.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Runtime;
+
+class Client
+{
+    /** @var string */
+    private $apiUrl;
+
+    public function __construct(string $apiUrl)
+    {
+        $this->apiUrl = $apiUrl;
+    }
+
+    /**
+     * Wait for the next lambda invocation and retrieve its data.
+     *
+     * This call is blocking because the Lambda runtime API is blocking.
+     *
+     * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-next
+     */
+    public function waitNextInvocation(): array
+    {
+        $handler = curl_init("http://{$this->apiUrl}/2018-06-01/runtime/invocation/next");
+        curl_setopt($handler, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($handler, CURLOPT_FAILONERROR, true);
+
+        // Retrieve invocation ID
+        $invocationId = '';
+        curl_setopt($handler, CURLOPT_HEADERFUNCTION, function ($ch, $header) use (&$invocationId) {
+            if (! preg_match('/:\s*/', $header)) {
+                return strlen($header);
+            }
+            [$name, $value] = preg_split('/:\s*/', $header, 2);
+            if (strtolower($name) === 'lambda-runtime-aws-request-id') {
+                $invocationId = trim($value);
+            }
+
+            return strlen($header);
+        });
+
+        // Retrieve body
+        $body = '';
+        curl_setopt($handler, CURLOPT_WRITEFUNCTION, function ($ch, $chunk) use (&$body) {
+            $body .= $chunk;
+
+            return strlen($chunk);
+        });
+
+        curl_exec($handler);
+        if (curl_error($handler)) {
+            throw new \Exception('Failed to fetch next Lambda invocation: ' . curl_error($handler));
+        }
+        if ($invocationId === '') {
+            throw new \Exception('Failed to determine the Lambda invocation ID');
+        }
+        if ($body === '') {
+            throw new \Exception('Empty Lambda runtime API response');
+        }
+        curl_close($handler);
+
+        $event = json_decode($body, true);
+
+        return [$invocationId, $event];
+    }
+
+    /**
+     * @param mixed $responseData
+     *
+     * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-response
+     */
+    public function sendResponse(string $invocationId, $responseData): void
+    {
+        $url = "http://{$this->apiUrl}/2018-06-01/runtime/invocation/$invocationId/response";
+        $this->postJson($url, $responseData);
+    }
+
+    /**
+     * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-invokeerror
+     */
+    public function signalFailure(string $invocationId, \Throwable $error): void
+    {
+        if ($error instanceof \Exception) {
+            $errorMessage = 'Uncaught ' . get_class($error) . ': ' . $error->getMessage();
+        } else {
+            $errorMessage = $error->getMessage();
+        }
+
+        // Log the exception in CloudWatch
+        printf(
+            "Fatal error: %s in %s:%d\nStack trace:\n%s",
+            $errorMessage,
+            $error->getFile(),
+            $error->getLine(),
+            $error->getTraceAsString()
+        );
+
+        // Send an "error" Lambda response
+        $url = "http://{$this->apiUrl}/2018-06-01/runtime/invocation/$invocationId/error";
+        $this->postJson($url, [
+            'errorMessage' => $error->getMessage(),
+            'errorType' => get_class($error),
+            'stackTrace' => explode(PHP_EOL, $error->getTraceAsString()),
+        ]);
+    }
+
+    /**
+     * @param mixed $data
+     */
+    private function postJson(string $url, $data): void
+    {
+        $jsonData = json_encode($data);
+        if ($jsonData === false) {
+            throw new \Exception('Failed encoding Lambda JSON response: ' . json_last_error_msg());
+        }
+
+        $handler = curl_init($url);
+        curl_setopt($handler, CURLOPT_CUSTOMREQUEST, 'POST');
+        curl_setopt($handler, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($handler, CURLOPT_POSTFIELDS, $jsonData);
+        curl_setopt($handler, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'Content-Length: ' . strlen($jsonData),
+        ]);
+        curl_exec($handler);
+        if (curl_error($handler)) {
+            $errorMessage = curl_error($handler);
+            throw new \Exception('Error while calling the Lambda runtime API: ' . $errorMessage);
+        }
+        curl_close($handler);
+    }
+}

--- a/src/Runtime/Event.php
+++ b/src/Runtime/Event.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Runtime;
+
+class Event
+{
+    /** @var mixed */
+    private $invocationId;
+
+    /** @var array */
+    private $data;
+
+    /** @var Client */
+    private $client;
+
+    public function __construct($invocationId, array $data, Client $client)
+    {
+        $this->invocationId = $invocationId;
+        $this->data = $data;
+        $this->client = $client;
+    }
+
+    public function data(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param mixed $response
+     */
+    public function fulfill($response): void
+    {
+        $this->client->sendResponse($this->invocationId, $response);
+    }
+
+    /**
+     * @param mixed $response
+     */
+    public function reject($response)
+    {
+        $this->client->signalFailure($this->invocationId, $response);
+    }
+}

--- a/src/Runtime/Event.php
+++ b/src/Runtime/Event.php
@@ -13,7 +13,7 @@ class Event
     /** @var Client */
     private $client;
 
-    public function __construct($invocationId, array $data, Client $client)
+    public function __construct(string $invocationId, array $data, Client $client)
     {
         $this->invocationId = $invocationId;
         $this->data = $data;
@@ -36,7 +36,7 @@ class Event
     /**
      * @param mixed $response
      */
-    public function reject($response)
+    public function reject($response): void
     {
         $this->client->signalFailure($this->invocationId, $response);
     }

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -22,21 +22,19 @@ namespace Bref\Runtime;
  */
 class LambdaRuntime
 {
-    /** @var string */
-    private $apiUrl;
+    /** @var Client */
+    private $client;
 
     public static function fromEnvironmentVariable(): self
     {
-        return new self(getenv('AWS_LAMBDA_RUNTIME_API'));
+        return new self(
+            new Client(getenv('AWS_LAMBDA_RUNTIME_API'))
+        );
     }
 
-    public function __construct(string $apiUrl)
+    public function __construct(Client $client)
     {
-        if ($apiUrl === '') {
-            die('At the moment lambdas can only be executed in an Lambda environment');
-        }
-
-        $this->apiUrl = $apiUrl;
+        $this->client = $client;
     }
 
     /**
@@ -52,130 +50,19 @@ class LambdaRuntime
      */
     public function processNextEvent(callable $handler): void
     {
-        [$invocationId, $event] = $this->waitNextInvocation();
+        [$invocationId, $event] = $this->client->waitNextInvocation();
 
         try {
-            $this->sendResponse($invocationId, $handler($event));
+            $this->client->sendResponse($invocationId, $handler($event));
         } catch (\Throwable $e) {
-            $this->signalFailure($invocationId, $e);
+            $this->client->signalFailure($invocationId, $e);
         }
     }
 
-    /**
-     * Wait for the next lambda invocation and retrieve its data.
-     *
-     * This call is blocking because the Lambda runtime API is blocking.
-     *
-     * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-next
-     */
-    private function waitNextInvocation(): array
+    public function fetchNextEvent(): Event
     {
-        $handler = curl_init("http://{$this->apiUrl}/2018-06-01/runtime/invocation/next");
-        curl_setopt($handler, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($handler, CURLOPT_FAILONERROR, true);
+        [$invocationId, $event] = $this->client->waitNextInvocation();
 
-        // Retrieve invocation ID
-        $invocationId = '';
-        curl_setopt($handler, CURLOPT_HEADERFUNCTION, function ($ch, $header) use (&$invocationId) {
-            if (! preg_match('/:\s*/', $header)) {
-                return strlen($header);
-            }
-            [$name, $value] = preg_split('/:\s*/', $header, 2);
-            if (strtolower($name) === 'lambda-runtime-aws-request-id') {
-                $invocationId = trim($value);
-            }
-
-            return strlen($header);
-        });
-
-        // Retrieve body
-        $body = '';
-        curl_setopt($handler, CURLOPT_WRITEFUNCTION, function ($ch, $chunk) use (&$body) {
-            $body .= $chunk;
-
-            return strlen($chunk);
-        });
-
-        curl_exec($handler);
-        if (curl_error($handler)) {
-            throw new \Exception('Failed to fetch next Lambda invocation: ' . curl_error($handler));
-        }
-        if ($invocationId === '') {
-            throw new \Exception('Failed to determine the Lambda invocation ID');
-        }
-        if ($body === '') {
-            throw new \Exception('Empty Lambda runtime API response');
-        }
-        curl_close($handler);
-
-        $event = json_decode($body, true);
-
-        return [$invocationId, $event];
-    }
-
-    /**
-     * @param mixed $responseData
-     *
-     * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-response
-     */
-    private function sendResponse(string $invocationId, $responseData): void
-    {
-        $url = "http://{$this->apiUrl}/2018-06-01/runtime/invocation/$invocationId/response";
-        $this->postJson($url, $responseData);
-    }
-
-    /**
-     * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-invokeerror
-     */
-    private function signalFailure(string $invocationId, \Throwable $error): void
-    {
-        if ($error instanceof \Exception) {
-            $errorMessage = 'Uncaught ' . get_class($error) . ': ' . $error->getMessage();
-        } else {
-            $errorMessage = $error->getMessage();
-        }
-
-        // Log the exception in CloudWatch
-        printf(
-            "Fatal error: %s in %s:%d\nStack trace:\n%s",
-            $errorMessage,
-            $error->getFile(),
-            $error->getLine(),
-            $error->getTraceAsString()
-        );
-
-        // Send an "error" Lambda response
-        $url = "http://{$this->apiUrl}/2018-06-01/runtime/invocation/$invocationId/error";
-        $this->postJson($url, [
-            'errorMessage' => $error->getMessage(),
-            'errorType' => get_class($error),
-            'stackTrace' => explode(PHP_EOL, $error->getTraceAsString()),
-        ]);
-    }
-
-    /**
-     * @param mixed $data
-     */
-    private function postJson(string $url, $data): void
-    {
-        $jsonData = json_encode($data);
-        if ($jsonData === false) {
-            throw new \Exception('Failed encoding Lambda JSON response: ' . json_last_error_msg());
-        }
-
-        $handler = curl_init($url);
-        curl_setopt($handler, CURLOPT_CUSTOMREQUEST, 'POST');
-        curl_setopt($handler, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($handler, CURLOPT_POSTFIELDS, $jsonData);
-        curl_setopt($handler, CURLOPT_HTTPHEADER, [
-            'Content-Type: application/json',
-            'Content-Length: ' . strlen($jsonData),
-        ]);
-        curl_exec($handler);
-        if (curl_error($handler)) {
-            $errorMessage = curl_error($handler);
-            throw new \Exception('Error while calling the Lambda runtime API: ' . $errorMessage);
-        }
-        curl_close($handler);
+        return new Event($invocationId, $event, $this->client);
     }
 }


### PR DESCRIPTION
This Pull Request introduces an `Event` object which contains the event data, a fulfill and a reject method.
The goal is to allow developers to decide when to consider an event fulfilled or rejected without having to rely on exceptions.

For me, the primary motivation for this PR is the Laravel Worker system. I'm basically trying to achieve #118, but I don't want to reinvent an entire worker system. The strongest reason are Laravel internal events. If I don't use the internal Worker, I won't get any of the Laravel events dispatched.

The way I intend to achieve this is the following: 

- Write a custom Queue Driver for Laravel with a LambdaConnector, a LambdaQueue and a LambdaJob.
- Call the `fetchNextEvent` from LambdaQueue and build a LambdaJob and return it.
- When the Worker finishes the job, it will dispatch a `JobProcessed` event, which I can then invoke `fulfill`,
- If the Worker fails to process the job, it will dispatch a `JobFailed` event, which I can then invoke the `reject` and make the message go back to the Queue.

The main reason why this cannot be achieved with the current state of Bref is because Laravel expects the event data to be fetched and returned to the Worker class, which then handles exceptions. In other words, doing `lambda(function ($event) {...})` would never throw an exception, which means all jobs would be considered successfully processed. The job isn't really being processed inside the handle. It is just gathering the event data and returning it.

With these changes, it becomes easy to make a Lambda function that gets triggered every time a new SQS Message comes and simply runs the standard Laravel worker through `php artisan queue:work --once`. By having a Service Provider that binds the `JobProcessed` and `JobFailed` events to the `fulfill` and `reject` methods, the job will be cleared or returned to the queue accordingly.