### PR TITLE
Publish runtime layer in eu-north-1 (Stockholm)

### DIFF
--- a/runtime/publish.php
+++ b/runtime/publish.php
@@ -29,6 +29,7 @@ foreach ($layers as $layer => $layerDescription) {
 $regions = [
     'ca-central-1',
     'eu-central-1',
+    'eu-north-1',
     'eu-west-1',
     'eu-west-2',
     'eu-west-3',


### PR DESCRIPTION
eu-north-1 (Stockholm) was missing from the list of regions where the runtime layer was available, and to be able to use bref in that region I added the region to the publish script.