### PR TITLE
Fix #214 by disabling the `fastcgi_finish_request()` function

### DIFF
--- a/runtime/php/layers/fpm/php.ini
+++ b/runtime/php/layers/fpm/php.ini
@@ -18,3 +18,7 @@ opcache.memory_consumption=128
 opcache.max_accelerated_files=10000
 
 zend_extension=opcache.so
+
+; The lambda environment is not compatible with fastcgi_finish_request
+; See https://github.com/mnapoli/bref/issues/214
+disable_functions=fastcgi_finish_request


### PR DESCRIPTION
This function is incompatible with Lambda's environment because when PHP-FPM sends the response, Bref sends it to Lambda and the lambda instance is then frozen. The terminate event will then probably run on the next invocation.

In Symfony this will force the `terminate` to run synchronously.