### PR TITLE
Add a "community" page in the documentation

### DIFF
--- a/couscous.yml
+++ b/couscous.yml
@@ -86,6 +86,10 @@ menu:
                 text: Case studies
                 url: /docs/case-studies.html
                 title: A collection of case studies of serverless PHP applications built using Bref.
+            community:
+                text: Community
+                url: /docs/community.html
+                title: Links to places where to exchange about Bref.
             newsletters:
                 text: Newsletters
                 url: /docs/newsletters.html

--- a/couscous.yml
+++ b/couscous.yml
@@ -89,8 +89,4 @@ menu:
             community:
                 text: Community
                 url: /docs/community.html
-                title: Links to places where to exchange about Bref.
-            newsletters:
-                text: Newsletters
-                url: /docs/newsletters.html
-                title: A collection of newsletters related to serverless and PHP.
+                title: Places where to learne and exchange about Bref.

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,15 @@
+---
+title: Community
+currentMenu: community
+introduction: A collection of links to places where to discuss and learn about Bref.
+---
+
+To report bugs you can head over to the [GitHub Bref repository](https://github.com/mnapoli/bref).
+
+You can also join the [Slack community](https://brefworkspace.slack.com/) to discuss Bref and exchange with the community.
+
+On Twitter use [#BrefPHP](https://twitter.com/search?q=%23BrefPHP) to follow and post news about Bref.
+
+## Contributors
+
+The full list of contributors to Bref is [available here](https://github.com/mnapoli/bref/graphs/contributors).

--- a/docs/community.md
+++ b/docs/community.md
@@ -6,10 +6,23 @@ introduction: A collection of links to places where to discuss and learn about B
 
 To report bugs you can head over to the [GitHub Bref repository](https://github.com/mnapoli/bref).
 
-You can also join the [Slack community](https://brefworkspace.slack.com/) to discuss Bref and exchange with the community.
+You can also join the [Slack community](https://join.slack.com/t/brefworkspace/shared_invite/enQtNTcwMjU2NTcxNjAxLWRiZGUzZGJiZDNmZmM4NWUwMThhNjhlYmNiZTY2ZDEwMTBlOWY1NjAyOWQzODQxY2JkMjFmOGZjOWE0Y2YzZTg) to discuss Bref and exchange with the community.
 
 On Twitter use [#BrefPHP](https://twitter.com/search?q=%23BrefPHP) to follow and post news about Bref.
 
 ## Contributors
 
 The full list of contributors to Bref is [available here](https://github.com/mnapoli/bref/graphs/contributors).
+
+## Newsletters
+
+Here are a few newsletters related to serverless and PHP. Those are not necessarily related to Bref.
+
+You can subscribe to these newsletters to keep up to date with what's happening in the serverless world.
+
+- [Serverless PHP](https://serverless-php.news/)
+
+    A monthly newsletter about serverless news related to PHP.
+- [Off by None](https://www.jeremydaly.com/newsletter/)
+
+    A very packed weekly newsletter about serverless news in general.

--- a/website/_redirects
+++ b/website/_redirects
@@ -1,0 +1,1 @@
+/docs/newsletters.html      /docs/community.html


### PR DESCRIPTION
This new page contains for example a link to the Slack workspace.