### PR TITLE
Fix #265 Recover from Lambda timeouts

### DIFF
--- a/demo/http.php
+++ b/demo/http.php
@@ -1,20 +1,9 @@
 <?php declare(strict_types=1);
 
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-
 require __DIR__ . '/../vendor/autoload.php';
 
-$slim = new Slim\App;
+if (isset($_GET['sleep'])) {
+    sleep(10);
+}
 
-$slim->get('/', function (ServerRequestInterface $request, ResponseInterface $response) {
-    $response->getBody()->write('Hello world!');
-    return $response;
-});
-$slim->get('/json', function (ServerRequestInterface $request, ResponseInterface $response) {
-    $response->getBody()->write(json_encode(['hello' => 'json']));
-    $response = $response->withHeader('Content-Type', 'application/json');
-    return $response;
-});
-
-$slim->run();
+echo 'Hello world!';

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,3 +12,7 @@ parameters:
     - %rootDir%/../../../tests/Bridge/Symfony/logs/*
     - %rootDir%/../../../tests/Sam/Php/*
     - %rootDir%/../../../tests/Sam/PhpFpm/*
+
+  ignoreErrors:
+    # https://github.com/phpstan/phpstan/pull/2002
+    - '#Strict comparison using === between int and false will always evaluate to false#'

--- a/runtime/php/layers/fpm/php-fpm.conf
+++ b/runtime/php/layers/fpm/php-fpm.conf
@@ -1,5 +1,6 @@
 ; Logging anywhere on disk doesn't make sense on lambda since instances are ephemeral
 error_log = /dev/null
+pid = /tmp/.bref/php-fpm.pid
 ; Log above warning because PHP-FPM logs useless notices
 ; We must comment this flag else uncaught exceptions/fatal errors are not reported in the logs!
 ; TODO: report that to the PHP bug tracker

--- a/template.yaml
+++ b/template.yaml
@@ -25,7 +25,7 @@ Resources:
             Description: 'Bref HTTP demo'
             CodeUri: .
             Handler: demo/http.php
-            Timeout: 30 # in seconds (API Gateway has a timeout of 30 seconds)
+            Timeout: 5 # in seconds (API Gateway has a timeout of 30 seconds)
             MemorySize: 1024 # The memory size is related to the pricing and CPU power
             Runtime: provided
             Layers:

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -701,7 +701,10 @@ Year,Make,Model
         ], $response['headers']);
     }
 
-    public function test timeouts are recovered from()
+    /**
+     * Checks that a timeout cause by the PHP-FPM limit (not the Lambda limit) can be recovered from
+     */
+    public function test FPM timeouts are recovered from()
     {
         $this->fpm = new PhpFpm(__DIR__ . '/PhpFpm/timeout.php', __DIR__ . '/PhpFpm/php-fpm.conf');
         $this->fpm->start();


### PR DESCRIPTION
In #257 I added some code to support and recover from PHP-FPM timeouts.

However we still have problems with Lambda timeouts (#265): those timeouts cause AWS Lambda to kill our `bootstrap` process and restart it.

I added some code to handle all scenarios I could think of: whether PHP-FPM was still running or not. From what I've seen in my tests Lambda correctly kills the `bootstrap` process but it kills PHP-FPM properly as well (see https://github.com/mnapoli/bref/issues/265#issuecomment-473368865). That's good, in those cases Bref will simply restart PHP-FPM and be good to go.

I cannot add regression tests because SAM recreates a new instance on every invocation, so it's impossible to keep a broken instance around. I tested directly on AWS Lambda.

This change requires a new layer version because `php-fpm.conf` is modified.
