### PR TITLE
Reproduce #290: `$_ENV` is not populated in PHP and PHP-FPM

### DIFF
--- a/runtime/php/layers/fpm/php.ini
+++ b/runtime/php/layers/fpm/php.ini
@@ -19,6 +19,13 @@ opcache.max_accelerated_files=10000
 
 zend_extension=opcache.so
 
+; This directive determines which super global arrays are registered when PHP
+; starts up. G,P,C,E & S are abbreviations for the following respective super
+; globals: GET, POST, COOKIE, ENV and SERVER.
+; We explicitly populate all variables else ENV is not populated by default.
+; See https://github.com/mnapoli/bref/pull/291
+variables_order="EGPCS"
+
 ; The lambda environment is not compatible with fastcgi_finish_request
 ; See https://github.com/mnapoli/bref/issues/214
 disable_functions=fastcgi_finish_request

--- a/runtime/php/layers/function/php.ini
+++ b/runtime/php/layers/function/php.ini
@@ -24,3 +24,10 @@ opcache.memory_consumption=128
 opcache.max_accelerated_files=10000
 
 zend_extension=opcache.so
+
+; This directive determines which super global arrays are registered when PHP
+; starts up. G,P,C,E & S are abbreviations for the following respective super
+; globals: GET, POST, COOKIE, ENV and SERVER.
+; We explicitly populate all variables else ENV is not populated by default.
+; See https://github.com/mnapoli/bref/pull/291
+variables_order="EGPCS"

--- a/tests/Sam/Php/function.php
+++ b/tests/Sam/Php/function.php
@@ -11,6 +11,14 @@ lambda(function (array $event) {
         return ini_get_all(null, false);
     }
 
+    if ($event['env'] ?? false) {
+        return [
+            '$_ENV' => $_ENV['FOO'] ?? null,
+            '$_SERVER' => $_SERVER['FOO'] ?? null,
+            'getenv' => getenv('FOO'),
+        ];
+    }
+
     if ($event['stdout'] ?? false) {
         echo 'This is a test log by writing to stdout';
     }

--- a/tests/Sam/PhpFpm/index.php
+++ b/tests/Sam/PhpFpm/index.php
@@ -12,6 +12,16 @@ if ($_GET['php-config'] ?? false) {
     return;
 }
 
+if ($_GET['env'] ?? false) {
+    header('Content-Type: application/json');
+    echo json_encode([
+        '$_ENV' => $_ENV['FOO'] ?? null,
+        '$_SERVER' => $_SERVER['FOO'] ?? null,
+        'getenv' => getenv('FOO'),
+    ], JSON_PRETTY_PRINT);
+    return;
+}
+
 if ($_GET['stderr'] ?? false) {
     $stderr = fopen('php://stderr', 'a');
     fwrite($stderr, 'This is a test log into stderr');

--- a/tests/Sam/PhpFpmRuntimeTest.php
+++ b/tests/Sam/PhpFpmRuntimeTest.php
@@ -172,6 +172,17 @@ class PhpFpmRuntimeTest extends TestCase
         ], $this->getJsonBody($response), false, $this->logs);
     }
 
+    public function test environment variables()
+    {
+        $response = $this->invoke('/?env=1');
+
+        self::assertEquals([
+            '$_ENV' => 'bar',
+            '$_SERVER' => 'bar',
+            'getenv' => 'bar',
+        ], $this->getJsonBody($response), $this->logs);
+    }
+
     /**
      * Check some PHP config values
      */

--- a/tests/Sam/PhpRuntimeTest.php
+++ b/tests/Sam/PhpRuntimeTest.php
@@ -223,6 +223,19 @@ LOGS;
         ], $result, $logs);
     }
 
+    public function test environment variables()
+    {
+        [$result, $logs] = $this->invokeLambda([
+            'env' => true,
+        ]);
+
+        self::assertEquals([
+            '$_ENV' => 'bar',
+            '$_SERVER' => 'bar',
+            'getenv' => 'bar',
+        ], $result, $logs);
+    }
+
     /**
      * @param mixed $event
      */

--- a/tests/Sam/template.yaml
+++ b/tests/Sam/template.yaml
@@ -11,6 +11,9 @@ Resources:
             Runtime: provided
             Layers:
                 - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:2'
+            Environment:
+                Variables:
+                    FOO: bar
 
     HttpFunction:
         Type: AWS::Serverless::Function
@@ -27,6 +30,9 @@ Resources:
                     Properties:
                         Path: /
                         Method: ANY
+            Environment:
+                Variables:
+                    FOO: bar
 
     MissingHandler:
         Type: AWS::Serverless::Function


### PR DESCRIPTION
See #290

`$_ENV` is not populated in the PHP-FPM runtime.

Fortunately thanks to @matt-allan's [awesome article](https://mattallan.me/posts/how-php-environment-variables-actually-work/) this might be why:

> There is also an `$_ENV` superglobal.  Just like `$_SERVER` it can be disabled by removing `E` from the [`variables_order` directive](https://secure.php.net/manual/en/ini.core.php#ini.variables-order).  The default value for [development](https://github.com/php/php-src/blob/master/php.ini-development#L627) and [production](https://github.com/php/php-src/blob/b167dbe3ae9201e725d9f02817849e65bbb50c02/php.ini-production#L627) is `GPCS`, meaning `$_ENV` is most likely empty on your server.

I am a bit confused and unsure what to do: `$_ENV` is not populated per PHP's default configuration, yet it is relied upon by some frameworks, especially Laravel (see #290).

Should we populate `$_ENV` by overloading PHP's default configuration?