### PR TITLE
Add content length header for more http methods

### DIFF
--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -219,7 +219,7 @@ class PhpFpm
         ];
 
         // See https://stackoverflow.com/a/5519834/245552
-        if ((strtoupper($event['httpMethod']) === 'POST') && ! isset($headers['content-type'])) {
+        if ((strtoupper($event['httpMethod']) !== 'GET') && ! isset($headers['content-type'])) {
             $headers['content-type'] = 'application/x-www-form-urlencoded';
         }
         if (isset($headers['content-type'])) {
@@ -227,7 +227,7 @@ class PhpFpm
         }
         // Auto-add the Content-Length header if it wasn't provided
         // See https://github.com/mnapoli/bref/issues/162
-        if ((strtoupper($event['httpMethod']) === 'POST') && ! isset($headers['content-length'])) {
+        if ((strtoupper($event['httpMethod']) !== 'GET') && ! isset($headers['content-length'])) {
             $headers['content-length'] = strlen($requestBody);
         }
         if (isset($headers['content-length'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -219,7 +219,7 @@ class PhpFpm
         $method = strtoupper($event['httpMethod']);
 
         // See https://stackoverflow.com/a/5519834/245552
-        if (! empty ($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {
+        if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {
             $headers['content-type'] = 'application/x-www-form-urlencoded';
         }
         if (isset($headers['content-type'])) {
@@ -227,7 +227,7 @@ class PhpFpm
         }
         // Auto-add the Content-Length header if it wasn't provided
         // See https://github.com/mnapoli/bref/issues/162
-        if (! empty ($requestBody) && $method !== 'TRACE' && ! isset($headers['content-length'])) {
+        if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-length'])) {
             $headers['content-length'] = strlen($requestBody);
         }
         if (isset($headers['content-length'])) {

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -207,13 +207,44 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
+    public function provideHttpMethodsWithRequestBody(): array
+    {
+        // Only POST, PUT and PATCH are defined to use a request body, TRACE is explicitly forbidden to use one.
+        // All other HTTP methods have "no defined semantics": https://tools.ietf.org/html/rfc7231#section-4.3
+        return [
+            'OPTIONS' => [
+                'method' => 'OPTIONS'
+            ],
+            'HEAD' => [
+                'method' => 'HEAD'
+            ],
+            'GET' => [
+                'method' => 'GET'
+            ],
+            'POST' => [
+                'method' => 'POST'
+            ],
+            'PUT' => [
+                'method' => 'PUT'
+            ],
+            'PATCH' => [
+                'method' => 'PATCH'
+            ],
+            'DELETE' => [
+                'method' => 'DELETE'
+            ],
+        ];
+    }
+
     /**
      * @see https://github.com/mnapoli/bref/issues/162
+     *
+     * @dataProvider provideHttpMethodsWithRequestBody
      */
-    public function test POST request with body and no content length()
+    public function test request with body and no content length(string $method)
     {
         $event = [
-            'httpMethod' => 'POST',
+            'httpMethod' => $method,
             'headers' => [
                 'Content-Type' => 'application/json',
                 // The Content-Length header is purposefully omitted
@@ -241,10 +272,13 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
-    public function test POST request supports utf8 characters in body()
+    /**
+     * @dataProvider provideHttpMethodsWithRequestBody
+     */
+    public function test request supports utf8 characters in body(string $method)
     {
         $event = [
-            'httpMethod' => 'POST',
+            'httpMethod' => $method,
             'headers' => [
                 'Content-Type' => 'text/plain; charset=UTF-8',
                 // The Content-Length header is purposefully omitted
@@ -499,10 +533,13 @@ Year,Make,Model
         ]);
     }
 
-    public function test POST request with base64 encoded body()
+    /**
+     * @dataProvider provideHttpMethodsWithRequestBody
+     */
+    public function test request with base64 encoded body(string $method)
     {
         $event = [
-            'httpMethod' => 'POST',
+            'httpMethod' => $method,
             'isBase64Encoded' => true,
             'headers' => [
                 'Content-Type' => 'application/x-www-form-urlencoded',
@@ -606,40 +643,6 @@ Year,Make,Model
         ]);
     }
 
-    /**
-     * @see https://github.com/mnapoli/bref/issues/162
-     */
-    public function test PATCH request with body and no content length()
-    {
-        $event = [
-            'httpMethod' => 'PATCH',
-            'headers' => [
-                'Content-Type' => 'application/json',
-                // The Content-Length header is purposefully omitted
-            ],
-            'body' => json_encode('Hello world!'),
-        ];
-        $this->assertGlobalVariables($event, [
-            '$_GET' => [],
-            '$_POST' => [],
-            '$_FILES' => [],
-            '$_COOKIE' => [],
-            '$_REQUEST' => [],
-            '$_SERVER' => [
-                'CONTENT_LENGTH' => '14',
-                'CONTENT_TYPE' => 'application/json',
-                'REQUEST_URI' => '/',
-                'PHP_SELF' => '/',
-                'PATH_INFO' => '/',
-                'REQUEST_METHOD' => 'PATCH',
-                'QUERY_STRING' => '',
-                'HTTP_CONTENT_TYPE' => 'application/json',
-                'HTTP_CONTENT_LENGTH' => '14',
-            ],
-            'HTTP_RAW_BODY' => '"Hello world!"',
-        ]);
-    }
-
     public function test DELETE request()
     {
         $event = [
@@ -659,40 +662,6 @@ Year,Make,Model
                 'QUERY_STRING' => '',
             ],
             'HTTP_RAW_BODY' => '',
-        ]);
-    }
-
-    /**
-     * @see https://github.com/mnapoli/bref/issues/162
-     */
-    public function test DELETE request with body and no content length()
-    {
-        $event = [
-            'httpMethod' => 'DELETE',
-            'headers' => [
-                'Content-Type' => 'application/json',
-                // The Content-Length header is purposefully omitted
-            ],
-            'body' => json_encode('Hello world!'),
-        ];
-        $this->assertGlobalVariables($event, [
-            '$_GET' => [],
-            '$_POST' => [],
-            '$_FILES' => [],
-            '$_COOKIE' => [],
-            '$_REQUEST' => [],
-            '$_SERVER' => [
-                'CONTENT_LENGTH' => '14',
-                'CONTENT_TYPE' => 'application/json',
-                'REQUEST_URI' => '/',
-                'PHP_SELF' => '/',
-                'PATH_INFO' => '/',
-                'REQUEST_METHOD' => 'DELETE',
-                'QUERY_STRING' => '',
-                'HTTP_CONTENT_TYPE' => 'application/json',
-                'HTTP_CONTENT_LENGTH' => '14',
-            ],
-            'HTTP_RAW_BODY' => '"Hello world!"',
         ]);
     }
 

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -533,13 +533,10 @@ Year,Make,Model
         ]);
     }
 
-    /**
-     * @dataProvider provideHttpMethodsWithRequestBody
-     */
-    public function test request with base64 encoded body(string $method)
+    public function test POST request with base64 encoded body()
     {
         $event = [
-            'httpMethod' => $method,
+            'httpMethod' => 'POST',
             'isBase64Encoded' => true,
             'headers' => [
                 'Content-Type' => 'application/x-www-form-urlencoded',

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -146,7 +146,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
             'httpMethod' => 'POST',
             'headers' => [
                 'Content-Type' => 'application/json',
-                'Content-Length' => mb_strlen(json_encode('Hello world!')),
+                'Content-Length' => strlen(json_encode('Hello world!')),
             ],
             'body' => json_encode('Hello world!'),
         ];
@@ -177,7 +177,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
             'httpMethod' => 'POST',
             'body' => 'foo=bar&bim=baz',
             'headers' => [
-                'Content-Length' => mb_strlen('foo=bar&bim=baz'),
+                'Content-Length' => strlen('foo=bar&bim=baz'),
             ],
         ];
         $this->assertGlobalVariables($event, [
@@ -241,37 +241,6 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
-    public function test PATCH request with body and no content length()
-    {
-        $event = [
-            'httpMethod' => 'PATCH',
-            'headers' => [
-                'Content-Type' => 'application/json',
-                // The Content-Length header is purposefully omitted
-            ],
-            'body' => json_encode('Hello world!'),
-        ];
-        $this->assertGlobalVariables($event, [
-            '$_GET' => [],
-            '$_POST' => [],
-            '$_FILES' => [],
-            '$_COOKIE' => [],
-            '$_REQUEST' => [],
-            '$_SERVER' => [
-                'CONTENT_LENGTH' => '14',
-                'CONTENT_TYPE' => 'application/json',
-                'REQUEST_URI' => '/',
-                'PHP_SELF' => '/',
-                'PATH_INFO' => '/',
-                'REQUEST_METHOD' => 'PATCH',
-                'QUERY_STRING' => '',
-                'HTTP_CONTENT_TYPE' => 'application/json',
-                'HTTP_CONTENT_LENGTH' => '14',
-            ],
-            'HTTP_RAW_BODY' => '"Hello world!"',
-        ]);
-    }
-
     public function test POST request supports utf8 characters in body()
     {
         $event = [
@@ -311,7 +280,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
             'headers' => [
                 // content-type instead of Content-Type
                 'content-type' => 'application/json',
-                'content-length' => mb_strlen('{}'),
+                'content-length' => strlen('{}'),
             ],
             'body' => '{}',
         ];
@@ -352,7 +321,7 @@ baz\r
             'httpMethod' => 'POST',
             'headers' => [
                 'Content-Type' => 'multipart/form-data; boundary=testBoundary',
-                'Content-Length' => mb_strlen($body),
+                'Content-Length' => strlen($body),
             ],
             'body' => $body,
         ];
@@ -399,7 +368,7 @@ Content-Disposition: form-data; name=\"delete[categories][]\"\r
             'httpMethod' => 'POST',
             'headers' => [
                 'Content-Type' => 'multipart/form-data; boundary=testBoundary',
-                'Content-Length' => mb_strlen($body),
+                'Content-Length' => strlen($body),
             ],
             'body' => $body,
         ];
@@ -490,7 +459,7 @@ Year,Make,Model
             'httpMethod' => 'POST',
             'headers' => [
                 'Content-Type' => 'multipart/form-data; boundary=testBoundary',
-                'Content-Length' => mb_strlen($body),
+                'Content-Length' => strlen($body),
             ],
             'body' => $body,
         ];
@@ -537,7 +506,7 @@ Year,Make,Model
             'isBase64Encoded' => true,
             'headers' => [
                 'Content-Type' => 'application/x-www-form-urlencoded',
-                'Content-Length' => mb_strlen('foo=bar'),
+                'Content-Length' => strlen('foo=bar'),
             ],
             'body' => base64_encode('foo=bar'),
         ];
@@ -637,6 +606,40 @@ Year,Make,Model
         ]);
     }
 
+    /**
+     * @see https://github.com/mnapoli/bref/issues/162
+     */
+    public function test PATCH request with body and no content length()
+    {
+        $event = [
+            'httpMethod' => 'PATCH',
+            'headers' => [
+                'Content-Type' => 'application/json',
+                // The Content-Length header is purposefully omitted
+            ],
+            'body' => json_encode('Hello world!'),
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [],
+            '$_SERVER' => [
+                'CONTENT_LENGTH' => '14',
+                'CONTENT_TYPE' => 'application/json',
+                'REQUEST_URI' => '/',
+                'PHP_SELF' => '/',
+                'PATH_INFO' => '/',
+                'REQUEST_METHOD' => 'PATCH',
+                'QUERY_STRING' => '',
+                'HTTP_CONTENT_TYPE' => 'application/json',
+                'HTTP_CONTENT_LENGTH' => '14',
+            ],
+            'HTTP_RAW_BODY' => '"Hello world!"',
+        ]);
+    }
+
     public function test DELETE request()
     {
         $event = [
@@ -656,6 +659,40 @@ Year,Make,Model
                 'QUERY_STRING' => '',
             ],
             'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
+    /**
+     * @see https://github.com/mnapoli/bref/issues/162
+     */
+    public function test DELETE request with body and no content length()
+    {
+        $event = [
+            'httpMethod' => 'DELETE',
+            'headers' => [
+                'Content-Type' => 'application/json',
+                // The Content-Length header is purposefully omitted
+            ],
+            'body' => json_encode('Hello world!'),
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [],
+            '$_SERVER' => [
+                'CONTENT_LENGTH' => '14',
+                'CONTENT_TYPE' => 'application/json',
+                'REQUEST_URI' => '/',
+                'PHP_SELF' => '/',
+                'PATH_INFO' => '/',
+                'REQUEST_METHOD' => 'DELETE',
+                'QUERY_STRING' => '',
+                'HTTP_CONTENT_TYPE' => 'application/json',
+                'HTTP_CONTENT_LENGTH' => '14',
+            ],
+            'HTTP_RAW_BODY' => '"Hello world!"',
         ]);
     }
 

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -307,6 +307,45 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
+    /**
+     * @dataProvider provideHttpMethodsWithRequestBody
+     */
+    public function test request with base64 encoded body(string $method)
+    {
+        $event = [
+            'httpMethod' => $method,
+            'isBase64Encoded' => true,
+            'headers' => [
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Content-Length' => strlen('foo=bar'),
+            ],
+            'body' => base64_encode('foo=bar'),
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [],
+            '$_POST' => [
+                'foo' => 'bar',
+            ],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'foo' => 'bar',
+            ],
+            '$_SERVER' => [
+                'CONTENT_LENGTH' => '7',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_URI' => '/',
+                'PHP_SELF' => '/',
+                'PATH_INFO' => '/',
+                'REQUEST_METHOD' => 'POST',
+                'QUERY_STRING' => '',
+                'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'HTTP_CONTENT_LENGTH' => '7',
+            ],
+            'HTTP_RAW_BODY' => 'foo=bar',
+        ]);
+    }
+
     public function test the content type header is not case sensitive()
     {
         $event = [

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -146,7 +146,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
             'httpMethod' => 'POST',
             'headers' => [
                 'Content-Type' => 'application/json',
-                'Content-Length' => strlen(json_encode('Hello world!')),
+                'Content-Length' => mb_strlen(json_encode('Hello world!')),
             ],
             'body' => json_encode('Hello world!'),
         ];
@@ -177,7 +177,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
             'httpMethod' => 'POST',
             'body' => 'foo=bar&bim=baz',
             'headers' => [
-                'Content-Length' => strlen('foo=bar&bim=baz'),
+                'Content-Length' => mb_strlen('foo=bar&bim=baz'),
             ],
         ];
         $this->assertGlobalVariables($event, [
@@ -207,45 +207,13 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
-    public function provideHttpMethodsWithRequestBodySupport(): array
-    {
-        // Only POST, PUT and PATCH are defined to use a request body, TRACE is explicitly forbidden to use one.
-        // For all other HTTP methods a request body has "no defined semantics":
-        // https://tools.ietf.org/html/rfc7231#section-4.3
-        return [
-            'OPTIONS' => [
-                'method' => 'OPTIONS'
-            ],
-            'HEAD' => [
-                'method' => 'HEAD'
-            ],
-            'GET' => [
-                'method' => 'GET'
-            ],
-            'POST' => [
-                'method' => 'POST'
-            ],
-            'PUT' => [
-                'method' => 'PUT'
-            ],
-            'PATCH' => [
-                'method' => 'PATCH'
-            ],
-            'DELETE' => [
-                'method' => 'DELETE'
-            ],
-        ];
-    }
-
     /**
      * @see https://github.com/mnapoli/bref/issues/162
-     *
-     * @dataProvider provideHttpMethodsWithRequestBodySupport
      */
-    public function test request with body and no content length(string $method)
+    public function test POST request with body and no content length()
     {
         $event = [
-            'httpMethod' => $method,
+            'httpMethod' => 'POST',
             'headers' => [
                 'Content-Type' => 'application/json',
                 // The Content-Length header is purposefully omitted
@@ -264,7 +232,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'REQUEST_URI' => '/',
                 'PHP_SELF' => '/',
                 'PATH_INFO' => '/',
-                'REQUEST_METHOD' => $method,
+                'REQUEST_METHOD' => 'POST',
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/json',
                 'HTTP_CONTENT_LENGTH' => '14',
@@ -273,13 +241,10 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
-    /**
-     * @dataProvider provideHttpMethodsWithRequestBodySupport
-     */
-    public function test request supports utf8 characters in body(string $method)
+    public function test POST request supports utf8 characters in body()
     {
         $event = [
-            'httpMethod' => $method,
+            'httpMethod' => 'POST',
             'headers' => [
                 'Content-Type' => 'text/plain; charset=UTF-8',
                 // The Content-Length header is purposefully omitted
@@ -299,51 +264,12 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'REQUEST_URI' => '/',
                 'PHP_SELF' => '/',
                 'PATH_INFO' => '/',
-                'REQUEST_METHOD' => $method,
+                'REQUEST_METHOD' => 'POST',
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'text/plain; charset=UTF-8',
                 'HTTP_CONTENT_LENGTH' => '10',
             ],
             'HTTP_RAW_BODY' => 'Hello 🌍',
-        ]);
-    }
-
-    /**
-     * @dataProvider provideHttpMethodsWithRequestBodySupport
-     */
-    public function test request with base64 encoded body(string $method)
-    {
-        $event = [
-            'httpMethod' => $method,
-            'isBase64Encoded' => true,
-            'headers' => [
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Content-Length' => strlen('foo=bar'),
-            ],
-            'body' => base64_encode('foo=bar'),
-        ];
-        $this->assertGlobalVariables($event, [
-            '$_GET' => [],
-            '$_POST' => [
-                'foo' => 'bar',
-            ],
-            '$_FILES' => [],
-            '$_COOKIE' => [],
-            '$_REQUEST' => [
-                'foo' => 'bar',
-            ],
-            '$_SERVER' => [
-                'CONTENT_LENGTH' => '7',
-                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_URI' => '/',
-                'PHP_SELF' => '/',
-                'PATH_INFO' => '/',
-                'REQUEST_METHOD' => $method,
-                'QUERY_STRING' => '',
-                'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'HTTP_CONTENT_LENGTH' => '7',
-            ],
-            'HTTP_RAW_BODY' => 'foo=bar',
         ]);
     }
 
@@ -354,7 +280,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
             'headers' => [
                 // content-type instead of Content-Type
                 'content-type' => 'application/json',
-                'content-length' => strlen('{}'),
+                'content-length' => mb_strlen('{}'),
             ],
             'body' => '{}',
         ];
@@ -395,7 +321,7 @@ baz\r
             'httpMethod' => 'POST',
             'headers' => [
                 'Content-Type' => 'multipart/form-data; boundary=testBoundary',
-                'Content-Length' => strlen($body),
+                'Content-Length' => mb_strlen($body),
             ],
             'body' => $body,
         ];
@@ -442,7 +368,7 @@ Content-Disposition: form-data; name=\"delete[categories][]\"\r
             'httpMethod' => 'POST',
             'headers' => [
                 'Content-Type' => 'multipart/form-data; boundary=testBoundary',
-                'Content-Length' => strlen($body),
+                'Content-Length' => mb_strlen($body),
             ],
             'body' => $body,
         ];
@@ -533,7 +459,7 @@ Year,Make,Model
             'httpMethod' => 'POST',
             'headers' => [
                 'Content-Type' => 'multipart/form-data; boundary=testBoundary',
-                'Content-Length' => strlen($body),
+                'Content-Length' => mb_strlen($body),
             ],
             'body' => $body,
         ];
@@ -580,7 +506,7 @@ Year,Make,Model
             'isBase64Encoded' => true,
             'headers' => [
                 'Content-Type' => 'application/x-www-form-urlencoded',
-                'Content-Length' => strlen('foo=bar'),
+                'Content-Length' => mb_strlen('foo=bar'),
             ],
             'body' => base64_encode('foo=bar'),
         ];

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -207,13 +207,44 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
+    public function provideHttpMethodsWithRequestBodySupport(): array
+    {
+        return [
+            'POST' => [
+                'method' => 'POST',
+            ],
+            'PUT' => [
+                'method' => 'PUT',
+            ],
+            'PATCH' => [
+                'method' => 'PATCH',
+            ],
+
+            // Should these be supported/tested?
+            'OPTIONS' => [
+                'method' => 'OPTIONS',
+            ],
+            'HEAD' => [
+                'method' => 'HEAD',
+            ],
+            'GET' => [
+                'method' => 'GET',
+            ],
+            'DELETE' => [
+                'method' => 'DELETE',
+            ],
+        ];
+    }
+
     /**
      * @see https://github.com/mnapoli/bref/issues/162
+     *
+     * @dataProvider provideHttpMethodsWithRequestBodySupport
      */
-    public function test POST request with body and no content length()
+    public function test request with body and no content length(string $method)
     {
         $event = [
-            'httpMethod' => 'POST',
+            'httpMethod' => $method,
             'headers' => [
                 'Content-Type' => 'application/json',
                 // The Content-Length header is purposefully omitted
@@ -232,7 +263,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'REQUEST_URI' => '/',
                 'PHP_SELF' => '/',
                 'PATH_INFO' => '/',
-                'REQUEST_METHOD' => 'POST',
+                'REQUEST_METHOD' => $method,
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/json',
                 'HTTP_CONTENT_LENGTH' => '14',
@@ -241,10 +272,13 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
-    public function test POST request supports utf8 characters in body()
+    /**
+     * @dataProvider provideHttpMethodsWithRequestBodySupport
+     */
+    public function test request supports utf8 characters in body(string $method)
     {
         $event = [
-            'httpMethod' => 'POST',
+            'httpMethod' => $method,
             'headers' => [
                 'Content-Type' => 'text/plain; charset=UTF-8',
                 // The Content-Length header is purposefully omitted
@@ -264,7 +298,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'REQUEST_URI' => '/',
                 'PHP_SELF' => '/',
                 'PATH_INFO' => '/',
-                'REQUEST_METHOD' => 'POST',
+                'REQUEST_METHOD' => $method,
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'text/plain; charset=UTF-8',
                 'HTTP_CONTENT_LENGTH' => '10',

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -207,10 +207,11 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
-    public function provideHttpMethodsWithRequestBody(): array
+    public function provideHttpMethodsWithRequestBodySupport(): array
     {
         // Only POST, PUT and PATCH are defined to use a request body, TRACE is explicitly forbidden to use one.
-        // All other HTTP methods have "no defined semantics": https://tools.ietf.org/html/rfc7231#section-4.3
+        // For all other HTTP methods a request body has "no defined semantics":
+        // https://tools.ietf.org/html/rfc7231#section-4.3
         return [
             'OPTIONS' => [
                 'method' => 'OPTIONS'
@@ -239,7 +240,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
     /**
      * @see https://github.com/mnapoli/bref/issues/162
      *
-     * @dataProvider provideHttpMethodsWithRequestBody
+     * @dataProvider provideHttpMethodsWithRequestBodySupport
      */
     public function test request with body and no content length(string $method)
     {
@@ -263,7 +264,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'REQUEST_URI' => '/',
                 'PHP_SELF' => '/',
                 'PATH_INFO' => '/',
-                'REQUEST_METHOD' => 'POST',
+                'REQUEST_METHOD' => $method,
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/json',
                 'HTTP_CONTENT_LENGTH' => '14',
@@ -273,7 +274,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
     }
 
     /**
-     * @dataProvider provideHttpMethodsWithRequestBody
+     * @dataProvider provideHttpMethodsWithRequestBodySupport
      */
     public function test request supports utf8 characters in body(string $method)
     {
@@ -298,7 +299,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'REQUEST_URI' => '/',
                 'PHP_SELF' => '/',
                 'PATH_INFO' => '/',
-                'REQUEST_METHOD' => 'POST',
+                'REQUEST_METHOD' => $method,
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'text/plain; charset=UTF-8',
                 'HTTP_CONTENT_LENGTH' => '10',
@@ -308,7 +309,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
     }
 
     /**
-     * @dataProvider provideHttpMethodsWithRequestBody
+     * @dataProvider provideHttpMethodsWithRequestBodySupport
      */
     public function test request with base64 encoded body(string $method)
     {
@@ -337,7 +338,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'REQUEST_URI' => '/',
                 'PHP_SELF' => '/',
                 'PATH_INFO' => '/',
-                'REQUEST_METHOD' => 'POST',
+                'REQUEST_METHOD' => $method,
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'HTTP_CONTENT_LENGTH' => '7',

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -241,6 +241,37 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
+    public function test PATCH request with body and no content length()
+    {
+        $event = [
+            'httpMethod' => 'PATCH',
+            'headers' => [
+                'Content-Type' => 'application/json',
+                // The Content-Length header is purposefully omitted
+            ],
+            'body' => json_encode('Hello world!'),
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [],
+            '$_SERVER' => [
+                'CONTENT_LENGTH' => '14',
+                'CONTENT_TYPE' => 'application/json',
+                'REQUEST_URI' => '/',
+                'PHP_SELF' => '/',
+                'PATH_INFO' => '/',
+                'REQUEST_METHOD' => 'PATCH',
+                'QUERY_STRING' => '',
+                'HTTP_CONTENT_TYPE' => 'application/json',
+                'HTTP_CONTENT_LENGTH' => '14',
+            ],
+            'HTTP_RAW_BODY' => '"Hello world!"',
+        ]);
+    }
+
     public function test POST request supports utf8 characters in body()
     {
         $event = [

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -219,20 +219,6 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
             'PATCH' => [
                 'method' => 'PATCH',
             ],
-
-            // Should these be supported/tested?
-            'OPTIONS' => [
-                'method' => 'OPTIONS',
-            ],
-            'HEAD' => [
-                'method' => 'HEAD',
-            ],
-            'GET' => [
-                'method' => 'GET',
-            ],
-            'DELETE' => [
-                'method' => 'DELETE',
-            ],
         ];
     }
 


### PR DESCRIPTION
**What**
Allow more than just POST requests to automatically add the Content-Length header within the PHP-FPM runtime. As per the HTTP spec, this should include at least `POST`, `PUT`, and `PATCH` - semantics for all other HTTP methods are undefined except for `TRACE`, which explicitly forbids the usage of a request body.

**Why**
Content-Length auto-detection appears to be a common feature at least in NGINX, which is the web server I'm used to in an environment with a server. It's simply better for DX and allows us to write RESTful services using Bref.

@mnapoli One question regarding the tests: The interface currently hardcodes POST in a few method names, what would be your preferred approach to add the other newly supported http methods? I'll add the tests to cover all methods and cases (Content-Length detection, base64 decoding) after that question was answered. :)

TODO:
- [x] Implement changes in PhpFpm runtime
- [x] Get feedback on how tests should be implemented
- [x] Implement tests