### PR TITLE
reuse curl handler

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -22,6 +22,9 @@ namespace Bref\Runtime;
  */
 class LambdaRuntime
 {
+    private $handler;
+    private $returnHandler;
+
     /** @var string */
     private $apiUrl;
 
@@ -37,6 +40,27 @@ class LambdaRuntime
         }
 
         $this->apiUrl = $apiUrl;
+    }
+
+    public function __destruct()
+    {
+        $this->closeHandler();
+        $this->closeReturnHandler();
+    }
+
+    private function closeHandler()
+    {
+        if (!is_null($this->handler)) {
+            curl_close($this->handler);
+            $this->handler = null;
+        }
+    }
+    private function closeReturnHandler()
+    {
+        if (!is_null($this->returnHandler)) {
+            curl_close($this->returnHandler);
+            $this->returnHandler = null;
+        }
     }
 
     /**
@@ -70,13 +94,15 @@ class LambdaRuntime
      */
     private function waitNextInvocation(): array
     {
-        $handler = curl_init("http://{$this->apiUrl}/2018-06-01/runtime/invocation/next");
-        curl_setopt($handler, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($handler, CURLOPT_FAILONERROR, true);
+        if (is_null($this->handler)) {
+            $this->handler = curl_init("http://{$this->apiUrl}/2018-06-01/runtime/invocation/next");
+            curl_setopt($this->handler, CURLOPT_FOLLOWLOCATION, true);
+            curl_setopt($this->handler, CURLOPT_FAILONERROR, true);
+        }
 
         // Retrieve invocation ID
         $invocationId = '';
-        curl_setopt($handler, CURLOPT_HEADERFUNCTION, function ($ch, $header) use (&$invocationId) {
+        curl_setopt($this->handler, CURLOPT_HEADERFUNCTION, function ($ch, $header) use (&$invocationId) {
             if (! preg_match('/:\s*/', $header)) {
                 return strlen($header);
             }
@@ -90,15 +116,17 @@ class LambdaRuntime
 
         // Retrieve body
         $body = '';
-        curl_setopt($handler, CURLOPT_WRITEFUNCTION, function ($ch, $chunk) use (&$body) {
+        curl_setopt($this->handler, CURLOPT_WRITEFUNCTION, function ($ch, $chunk) use (&$body) {
             $body .= $chunk;
 
             return strlen($chunk);
         });
 
-        curl_exec($handler);
-        if (curl_error($handler)) {
-            throw new \Exception('Failed to fetch next Lambda invocation: ' . curl_error($handler));
+        curl_exec($this->handler);
+        if (curl_errno($this->handler) > 0) {
+            $message = curl_error($this->handler);
+            $this->closeHandler();
+            throw new \Exception('Failed to fetch next Lambda invocation: ' . $message);
         }
         if ($invocationId === '') {
             throw new \Exception('Failed to determine the Lambda invocation ID');
@@ -106,7 +134,6 @@ class LambdaRuntime
         if ($body === '') {
             throw new \Exception('Empty Lambda runtime API response');
         }
-        curl_close($handler);
 
         $event = json_decode($body, true);
 
@@ -196,21 +223,25 @@ class LambdaRuntime
             throw new \Exception('Failed encoding Lambda JSON response: ' . json_last_error_msg());
         }
 
-        $handler = curl_init($url);
-        curl_setopt($handler, CURLOPT_CUSTOMREQUEST, 'POST');
-        curl_setopt($handler, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($handler, CURLOPT_FAILONERROR, true);
-        curl_setopt($handler, CURLOPT_POSTFIELDS, $jsonData);
-        curl_setopt($handler, CURLOPT_HTTPHEADER, [
+
+        if (is_null($this->returnHandler)) {
+            $this->returnHandler = curl_init();
+            curl_setopt($this->returnHandler, CURLOPT_CUSTOMREQUEST, 'POST');
+            curl_setopt($this->returnHandler, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($this->returnHandler, CURLOPT_FAILONERROR, true);
+        }
+
+        curl_setopt($this->returnHandler, CURLOPT_URL, $url);
+        curl_setopt($this->returnHandler, CURLOPT_POSTFIELDS, $jsonData);
+        curl_setopt($this->returnHandler, CURLOPT_HTTPHEADER, [
             'Content-Type: application/json',
             'Content-Length: ' . strlen($jsonData),
         ]);
-        curl_exec($handler);
-        if (curl_error($handler)) {
-            $errorMessage = curl_error($handler);
-            curl_close($handler);
+        curl_exec($this->returnHandler);
+        if (curl_errno($this->returnHandler) > 0) {
+            $errorMessage = curl_error($this->returnHandler);
+            $this->closeReturnHandler();
             throw new \Exception('Error while calling the Lambda runtime API: ' . $errorMessage);
         }
-        curl_close($handler);
     }
 }

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -22,10 +22,10 @@ namespace Bref\Runtime;
  */
 class LambdaRuntime
 {
-    /** @var resource */
+    /** @var resource|null */
     private $handler;
 
-    /** @var resource */
+    /** @var resource|null */
     private $returnHandler;
 
     /** @var string */

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -22,7 +22,10 @@ namespace Bref\Runtime;
  */
 class LambdaRuntime
 {
+    /** @var resource */
     private $handler;
+
+    /** @var resource */
     private $returnHandler;
 
     /** @var string */
@@ -48,16 +51,16 @@ class LambdaRuntime
         $this->closeReturnHandler();
     }
 
-    private function closeHandler()
+    private function closeHandler(): void
     {
-        if (!is_null($this->handler)) {
+        if ($this->handler !== null) {
             curl_close($this->handler);
             $this->handler = null;
         }
     }
-    private function closeReturnHandler()
+    private function closeReturnHandler(): void
     {
-        if (!is_null($this->returnHandler)) {
+        if ($this->returnHandler !== null) {
             curl_close($this->returnHandler);
             $this->returnHandler = null;
         }
@@ -94,7 +97,7 @@ class LambdaRuntime
      */
     private function waitNextInvocation(): array
     {
-        if (is_null($this->handler)) {
+        if ($this->handler === null) {
             $this->handler = curl_init("http://{$this->apiUrl}/2018-06-01/runtime/invocation/next");
             curl_setopt($this->handler, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($this->handler, CURLOPT_FAILONERROR, true);
@@ -223,8 +226,7 @@ class LambdaRuntime
             throw new \Exception('Failed encoding Lambda JSON response: ' . json_last_error_msg());
         }
 
-
-        if (is_null($this->returnHandler)) {
+        if ($this->returnHandler === null) {
             $this->returnHandler = curl_init();
             curl_setopt($this->returnHandler, CURLOPT_CUSTOMREQUEST, 'POST');
             curl_setopt($this->returnHandler, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
**What**

Reuses the curl connection handle in the lambda runtime.

**Why**

curl_init creates always a new connection. As we are constantly talking to the same server this could be avoided. This will save some milliseconds on each recurring invocation.