### PR TITLE
Enable socketsets

### DIFF
--- a/runtime/php/php.Dockerfile
+++ b/runtime/php/php.Dockerfile
@@ -390,6 +390,7 @@ RUN set -xe \
         --prefix=${INSTALL_DIR} \
         --enable-option-checking=fatal \
         --enable-maintainer-zts \
+        --enable-sockets \
         --with-config-file-path=${INSTALL_DIR}/etc/php \
         --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/conf.d:/var/task/php/conf.d \
         --enable-fpm \


### PR DESCRIPTION
References #301 

 - [32M] **php-73-fpm.zip** _(106M uncompressed)_
 - [25M] **php-73.zip** _(79M uncompressed)_

Alternatively, when I zip them with `-y` storing symbolic links as the link instead of the referenced file.

 - [19M] **php-73-fpm.zip** _(64M uncompressed)_
 - [16M] **php-73.zip** _(50M uncompressed)_

