### PR TITLE
Add a new `bref deployment` command to debug failed deployments

### DIFF
--- a/bref
+++ b/bref
@@ -2,6 +2,7 @@
 <?php
 declare(strict_types=1);
 
+use Aws\CloudFormation\CloudFormationClient;
 use Bref\Lambda\InvocationFailed;
 use Bref\Lambda\SimpleLambdaClient;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -156,5 +157,74 @@ $app->command('invoke function [--region=] [-e|--event=]', function (string $fun
 })->descriptions('Invoke the lambda on the serverless provider', [
     '--event' => 'Event data as JSON, e.g. `--event \'{"name":"matt"}\'`',
 ]);
+
+$app->command('deployment stack-name [--region=]', function (string $stackName, ?string $region, SymfonyStyle $io) {
+    $cloudFormation = new CloudFormationClient([
+        'version' => 'latest',
+        'region' => ($region ?: getenv('AWS_DEFAULT_REGION')) ?: 'us-east-1',
+    ]);
+
+    $result = $cloudFormation->describeStackEvents([
+        'StackName' => $stackName,
+    ]);
+    $events = $result->get('StackEvents');
+
+    // Last events last
+    $events = array_reverse($events);
+    // Keep only events from the last 24 hours
+    $oneDayAgo = new DateTimeImmutable('-1 day');
+    $events = array_filter($events, function (array $event) use ($oneDayAgo) {
+        return $event['Timestamp'] >= $oneDayAgo;
+    });
+
+    if (empty($events)) {
+        $io->writeln('<info>No events were found in the last 24 hours.</info>');
+        return 0;
+    }
+
+    $errors = [];
+    foreach ($events as $event) {
+        /** @var DateTimeInterface $time */
+        $time = $event['Timestamp'];
+
+        $status = $event['ResourceStatus'];
+        $error = false;
+        if (strpos($status, 'FAILED') !== false) {
+            $error = true;
+            $errors[] = $event;
+        }
+
+        $io->write(sprintf(
+            '<comment>%s</comment> %s %s',
+            $time->format('M j G:H'),
+            $error ? "<error>$status</error>" : $status,
+            $event['ResourceType']
+        ));
+
+        if (isset($event['ResourceStatusReason'])) {
+            $io->write(" <info>{$event['ResourceStatusReason']}</info>");
+        }
+        $io->writeln('');
+    }
+    $io->writeln('');
+
+    if (empty($errors)) {
+        $io->writeln('<info>No errors found.</info>');
+    } else {
+        $io->writeln('<error>Summary of the errors found:</error>');
+        foreach ($errors as $event) {
+            /** @var DateTimeInterface $time */
+            $time = $event['Timestamp'];
+            $io->writeln(sprintf(
+                '<comment>%s</comment> <info>%s</info> %s',
+                $time->format('M j G:H'),
+                $event['ResourceType'],
+                $event['ResourceStatusReason'] ?? ''
+            ));
+        }
+    }
+
+    return 0;
+})->descriptions('Displays the latest deployment logs from CloudFormation. Only the logs from the last 24 hours are displayed. Use these logs to debug why a deployment failed.');
 
 $app->run();

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -82,7 +82,13 @@ sam deploy \
 
 > `<stack-name>` can be the name of your project (made of letters, numbers and `-`).
 
-While you wait for your stack to be created you can check out [the CloudFormation dashboard](https://us-east-2.console.aws.amazon.com/cloudformation/home). You will see your stack appear there. In case of an error, click on your stack and check out the *Events* tab to see what went wrong.
+While you wait for your stack to be created you can check out [the CloudFormation dashboard](https://console.aws.amazon.com/cloudformation/home). Your stack will appear there.
+
+If an error occurs, you can either look into the *Events* tab of your stack in the CloudFormation dashboard or use the following Bref command to understand what went wrong:
+
+```bash
+vendor/bin/bref deployment <stack-name>
+```
 
 ## Automating deployments
 


### PR DESCRIPTION
If an error occurs when deploying with SAM we need to look into the *Events* tab of the stack in the CloudFormation dashboard.

This works but isn't friendly and practical. This PR introduces the following Bref command to list the logs from the latest deployments and understand what went wrong:

```bash
vendor/bin/bref deployment <stack-name>
```

Only events from the last 24 hours are displayed. We could make it configurable in the future (PRs welcome).

Preview of the output:

![Capture d’écran 2019-04-16 à 20 47 21](https://user-images.githubusercontent.com/720328/56236562-3b68fb80-608a-11e9-83f4-9f598afb56ab.png)
