### PR TITLE
tell the user to run aws configure when process exits

### DIFF
--- a/bref
+++ b/bref
@@ -7,6 +7,7 @@ use Bref\Lambda\InvocationFailed;
 use Bref\Lambda\SimpleLambdaClient;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -37,7 +38,20 @@ $app->command('init', function (SymfonyStyle $io) {
         // Credentials are not configured with environment variables, check aws cli
         $awsProcess1 = new Process(['aws', 'configure', 'get', 'aws_access_key_id']);
         $awsProcess2 = new Process(['aws', 'configure', 'get', 'aws_secret_access_key']);
-        if (($awsProcess1->run() !== 0) || ($awsProcess2->run() !== 0)) {
+
+        try {
+            $accessKeyProcessResult = $awsProcess1->run();
+            $secretProcessResult = $awsProcess2->run();
+        } catch (ProcessSignaledException $exception) {
+            $io->error([
+                'Running `aws configure` failed',
+                'Please try running `aws configure` yourself for more debug information'
+            ]);
+
+            return 1;
+        }
+
+        if ($accessKeyProcessResult !== 0 || $secretProcessResult !== 0) {
             $io->error([
                 'AWS credentials not found.',
                 'Please follow the instructions at https://bref.sh/docs/installation.html',


### PR DESCRIPTION
When running `aws configure`, if the process throws a `ProcessSignaledException` we should catch it and give the user a bit more information on how to dig into the problem, otherwise they have to follow the stack trace through Bref's code to try to figure out what we were trying to do at the time it borked.

refs: https://github.com/mnapoli/bref/issues/322