### PR TITLE
Handling keepWarm events to mitigate cold start

### DIFF
--- a/docs/runtimes/http.md
+++ b/docs/runtimes/http.md
@@ -136,3 +136,21 @@ Use `{foo}` as a placeholder for a parameter and `{foo+}` as a parameter that ma
 Lambda and API Gateway are only used for executing code. Serving assets via PHP does not make sense as this would be a waste of resources and money.
 
 Deploying a website and serving assets (e.g. CSS, JavaScript, images) will be covered later in another article.
+
+### Cold start
+
+AWS Lambda automatically destroys Lambda containers that have been unused for 10 to 60 minutes. Warming up a new container can take severals seconds, especially if your package is large or if your Lambda is connected to a VPC. This delay is called [cold start](https://mikhail.io/serverless/coldstarts/aws/).
+
+To mitigate cold start, you can periodically send an event to your Lambda including a `{warmer: true}` key. Bref recognizes this event and immediately responds with a `{status: 100}` without calling your handler file.  
+
+You can generate automatically such events using AWS CloudWatch. For exemple : 
+
+```yaml
+            Events:
+                ...
+                Warmer:
+                    Type: Schedule
+                    Properties:
+                        Schedule: rate(5 minutes)
+                        Input: '{"warmer": true}'
+```

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -107,6 +107,10 @@ class PhpFpm
      */
     public function proxy($event): LambdaResponse
     {
+        if (isset($event['warmer']) && $event['warmer'] === true) {
+            return new LambdaResponse(100, [], 'Lambda is warm');
+        }
+
         if (! isset($event['httpMethod'])) {
             throw new \Exception('The lambda was not invoked via HTTP through API Gateway: this is not supported by this runtime');
         }


### PR DESCRIPTION
Hi all !  
Thanks for your work on this awesome project !

We can prevent our Lambda container from dying by calling it periodically.
[Jeremy Daly explains here](https://www.jeremydaly.com/lambda-warmer-optimize-aws-lambda-function-cold-starts/) how he created [Lambda Warmer](https://www.npmjs.com/package/lambda-warmer), a simple Node.js plugin that waits for a special kind of event and replies without running the whole function. 

I tried to generate such events using CloudWatch but I got my logs polluted with Excpetion messages.  
This PR allows us to send keepWarm events using CloudWatch without polluting the logs.

This is a first version as it doesn't manage yet the multiple concurrency warming. But it can be usefull to test on small applications.
