### PR TITLE
Display the CloudFormation outputs in the `deployment` command

### DIFF
--- a/bref
+++ b/bref
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Aws\CloudFormation\CloudFormationClient;
+use Aws\CloudFormation\Exception\CloudFormationException;
 use Bref\Lambda\InvocationFailed;
 use Bref\Lambda\SimpleLambdaClient;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -173,10 +174,32 @@ $app->command('invoke function [--region=] [-e|--event=]', function (string $fun
 ]);
 
 $app->command('deployment stack-name [--region=]', function (string $stackName, ?string $region, SymfonyStyle $io) {
+    $region = ($region ?: getenv('AWS_DEFAULT_REGION')) ?: 'us-east-1';
     $cloudFormation = new CloudFormationClient([
         'version' => 'latest',
-        'region' => ($region ?: getenv('AWS_DEFAULT_REGION')) ?: 'us-east-1',
+        'region' => $region,
     ]);
+
+    try {
+        $result = $cloudFormation->describeStacks([
+            'StackName' => $stackName,
+        ]);
+        $stacks = $result->get('Stacks');
+        if (!isset($stacks[0])) {
+            $io->error(sprintf('The stack %s cannot be found in region %s', $stackName, $region));
+            return 1;
+        }
+        $stack = $stacks[0];
+    } catch (CloudFormationException $e) {
+        $io->error([
+            "Error while fetching information about the stack `$stackName` in region `$region`:",
+            sprintf('"%s"', $e->getAwsErrorMessage()),
+            "In case the stack was not found make sure that `$region` is the correct region.",
+        ]);
+        return 1;
+    }
+
+    $io->section('Events');
 
     $result = $cloudFormation->describeStackEvents([
         'StackName' => $stackName,
@@ -192,50 +215,60 @@ $app->command('deployment stack-name [--region=]', function (string $stackName, 
     });
 
     if (empty($events)) {
-        $io->writeln('<info>No events were found in the last 24 hours.</info>');
-        return 0;
-    }
-
-    $errors = [];
-    foreach ($events as $event) {
-        /** @var DateTimeInterface $time */
-        $time = $event['Timestamp'];
-
-        $status = $event['ResourceStatus'];
-        $error = false;
-        if (strpos($status, 'FAILED') !== false) {
-            $error = true;
-            $errors[] = $event;
-        }
-
-        $io->write(sprintf(
-            '<comment>%s</comment> %s %s',
-            $time->format('M j G:H'),
-            $error ? "<error>$status</error>" : $status,
-            $event['ResourceType']
-        ));
-
-        if (isset($event['ResourceStatusReason'])) {
-            $io->write(" <info>{$event['ResourceStatusReason']}</info>");
-        }
-        $io->writeln('');
-    }
-    $io->writeln('');
-
-    if (empty($errors)) {
-        $io->writeln('<info>No errors found.</info>');
+        $io->text('No events were found in the last 24 hours.');
     } else {
-        $io->writeln('<error>Summary of the errors found:</error>');
-        foreach ($errors as $event) {
+        $errors = [];
+        foreach ($events as $event) {
             /** @var DateTimeInterface $time */
             $time = $event['Timestamp'];
-            $io->writeln(sprintf(
-                '<comment>%s</comment> <info>%s</info> %s',
+
+            $status = $event['ResourceStatus'];
+            $error = false;
+            if (strpos($status, 'FAILED') !== false) {
+                $error = true;
+                $errors[] = $event;
+            }
+
+            $io->write(sprintf(
+                '<comment>%s</comment> %s %s',
                 $time->format('M j G:H'),
-                $event['ResourceType'],
-                $event['ResourceStatusReason'] ?? ''
+                $error ? "<error>$status</error>" : $status,
+                $event['ResourceType']
             ));
+
+            if (isset($event['ResourceStatusReason'])) {
+                $io->write(" <info>{$event['ResourceStatusReason']}</info>");
+            }
+            $io->writeln('');
         }
+        $io->writeln('');
+
+        if (empty($errors)) {
+            $io->writeln('<info>No errors found.</info>');
+        } else {
+            $io->writeln('<error>Summary of the errors found:</error>');
+            foreach ($errors as $event) {
+                /** @var DateTimeInterface $time */
+                $time = $event['Timestamp'];
+                $io->writeln(sprintf(
+                    '<comment>%s</comment> <info>%s</info> %s',
+                    $time->format('M j G:H'),
+                    $event['ResourceType'],
+                    $event['ResourceStatusReason'] ?? ''
+                ));
+            }
+        }
+    }
+
+    if (isset($stack['Outputs']) && !empty($stack['Outputs'])) {
+        $io->section('Outputs');
+        $io->listing(array_map(function (array $output): string {
+            return sprintf(
+                '%s: <info>%s</info>',
+                $output['Description'] ?? $output['OutputKey'],
+                $output['OutputValue']
+            );
+        }, $stack['Outputs']));
     }
 
     return 0;


### PR DESCRIPTION
The `bref deployment` command currently displays the events of the latest deployments.

With this change the command will also display the "outputs" of the CloudFormation stack.

The practical side of this is that we can now get the URL of a HTTP application that we just deployed. Without this we need to log into the AWS console and check the stack in the CloudFormation dashboard… Less practical.

Here is what the new feature looks like:

![Capture d’écran 2019-05-19 à 22 41 55](https://user-images.githubusercontent.com/720328/57987867-d12be800-7a87-11e9-8dbe-e562ebbf1b29.png)
