### PR TITLE
Update to latest runtimes

### DIFF
--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -39,7 +39,7 @@ Resources:
             Timeout: 30 # in seconds (API Gateway has a timeout of 30 seconds)
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-72-fpm:4'
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-72-fpm:6'
             Events:
                 # The function will match all HTTP URLs
                 HttpRoot:
@@ -62,9 +62,9 @@ Resources:
             Runtime: provided
             Layers:
                 # PHP runtime
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-72:4'
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-72:6'
                 # Console layer
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:console:4'
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:console:6'
 
 Outputs:
     DemoHttpApi:

--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -39,7 +39,7 @@ Resources:
             MemorySize: 1024
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73-fpm:4'
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73-fpm:6'
             Events:
                 HttpRoot:
                     Type: Api
@@ -61,8 +61,8 @@ Resources:
             Timeout: 120 # in seconds
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:4' # PHP
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:console:4' # The "console" layer
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:6' # PHP
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:console:6' # The "console" layer
 
 Outputs:
     DemoApi:

--- a/template.yaml
+++ b/template.yaml
@@ -16,7 +16,7 @@ Resources:
             Handler: demo/function.php
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-2:209497400698:layer:php-72:4'
+                - 'arn:aws:lambda:us-east-2:209497400698:layer:php-72:6'
 
     HttpFunction:
         Type: AWS::Serverless::Function
@@ -29,7 +29,7 @@ Resources:
             MemorySize: 1024 # The memory size is related to the pricing and CPU power
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-2:209497400698:layer:php-72-fpm:4'
+                - 'arn:aws:lambda:us-east-2:209497400698:layer:php-72-fpm:6'
             Events:
                 HttpRoot:
                     Type: Api
@@ -51,8 +51,8 @@ Resources:
             Handler: demo/console.php
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-2:209497400698:layer:php-72:4'
-                - 'arn:aws:lambda:us-east-2:209497400698:layer:console:4'
+                - 'arn:aws:lambda:us-east-2:209497400698:layer:php-72:6'
+                - 'arn:aws:lambda:us-east-2:209497400698:layer:console:6'
 
 Outputs:
     DemoHttpApi:

--- a/template/console/template.yaml
+++ b/template/console/template.yaml
@@ -14,5 +14,5 @@ Resources:
             MemorySize: 1024 # The memory size is related to the pricing and CPU power
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:4' # PHP
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:console:4' # The "console" layer
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:6' # PHP
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:console:6' # The "console" layer

--- a/template/default/template.yaml
+++ b/template/default/template.yaml
@@ -14,4 +14,4 @@ Resources:
             MemorySize: 1024 # The memory size is related to the pricing and CPU power
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:4'
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:6'

--- a/template/http/template.yaml
+++ b/template/http/template.yaml
@@ -14,7 +14,7 @@ Resources:
             MemorySize: 1024 # The memory size is related to the pricing and CPU power
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73-fpm:4'
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73-fpm:6'
             Events:
                 # The function will match all HTTP URLs
                 HttpRoot:

--- a/tests/Sam/template.yaml
+++ b/tests/Sam/template.yaml
@@ -10,7 +10,7 @@ Resources:
             Handler: tests/Sam/Php/function.php
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:4'
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:6'
             Environment:
                 Variables:
                     FOO: bar
@@ -23,7 +23,7 @@ Resources:
             Handler: tests/Sam/PhpFpm/index.php
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73-fpm:4'
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73-fpm:6'
             Events:
                 HttpRoot:
                     Type: Api
@@ -42,7 +42,7 @@ Resources:
             Handler: tests/Sam/PhpFpm/UNKNOWN.php
             Runtime: provided
             Layers:
-                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73-fpm:4'
+                - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73-fpm:6'
             Events:
                 HttpRoot:
                     Type: Api


### PR DESCRIPTION
I updated everything to the latest layer versions. I recently ran `init` on a new project and realized it was still referencing `:4`