### PR TITLE
Define explicitly the public API of the Bref codebase

### DIFF
--- a/src/Context/ContextBuilder.php
+++ b/src/Context/ContextBuilder.php
@@ -2,7 +2,10 @@
 
 namespace Bref\Context;
 
-class ContextBuilder
+/**
+ * @internal
+ */
+final class ContextBuilder
 {
     /** @var string */
     private $awsRequestId;

--- a/src/Http/LambdaResponse.php
+++ b/src/Http/LambdaResponse.php
@@ -6,8 +6,10 @@ use Psr\Http\Message\ResponseInterface;
 
 /**
  * Formats the response expected by AWS Lambda and the API Gateway integration.
+ *
+ * @internal
  */
-class LambdaResponse
+final class LambdaResponse
 {
     /** @var int */
     private $statusCode = 200;

--- a/src/Lambda/InvocationFailed.php
+++ b/src/Lambda/InvocationFailed.php
@@ -2,7 +2,7 @@
 
 namespace Bref\Lambda;
 
-class InvocationFailed extends \Exception
+final class InvocationFailed extends \Exception
 {
     /** @var InvocationResult */
     private $invocationResult;

--- a/src/Lambda/InvocationResult.php
+++ b/src/Lambda/InvocationResult.php
@@ -7,7 +7,7 @@ use Aws\Result;
 /**
  * The result of a successful lambda invocation.
  */
-class InvocationResult
+final class InvocationResult
 {
     /** @var Result */
     private $result;

--- a/src/Lambda/SimpleLambdaClient.php
+++ b/src/Lambda/SimpleLambdaClient.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\StreamInterface;
 /**
  * A simpler alternative to the official LambdaClient from the AWS SDK.
  */
-class SimpleLambdaClient
+final class SimpleLambdaClient
 {
     /** @var LambdaClient */
     private $lambda;

--- a/src/Runtime/FastCgi/FastCgiCommunicationFailed.php
+++ b/src/Runtime/FastCgi/FastCgiCommunicationFailed.php
@@ -4,7 +4,9 @@ namespace Bref\Runtime\FastCgi;
 
 /**
  * There was an error while communicating with FastCGI.
+ *
+ * @internal
  */
-class FastCgiCommunicationFailed extends \Exception
+final class FastCgiCommunicationFailed extends \Exception
 {
 }

--- a/src/Runtime/FastCgi/FastCgiRequest.php
+++ b/src/Runtime/FastCgi/FastCgiRequest.php
@@ -4,7 +4,10 @@ namespace Bref\Runtime\FastCgi;
 
 use hollodotme\FastCGI\Requests\AbstractRequest;
 
-class FastCgiRequest extends AbstractRequest
+/**
+ * @internal
+ */
+final class FastCgiRequest extends AbstractRequest
 {
     /** @var string */
     private $method;

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -22,8 +22,10 @@ use Bref\Context\ContextBuilder;
  *     $lambdaRuntime->processNextEvent(function ($event) {
  *         return <response>;
  *     });
+ *
+ * @internal
  */
-class LambdaRuntime
+final class LambdaRuntime
 {
     /** @var resource|null */
     private $handler;

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -21,8 +21,10 @@ use Symfony\Component\Process\Process;
  *     $lambdaResponse = $phpFpm->proxy($event);
  *     $phpFpm->stop();
  *     [send the $lambdaResponse];
+ *
+ * @internal
  */
-class PhpFpm
+final class PhpFpm
 {
     private const SOCKET = '/tmp/.bref/php-fpm.sock';
     private const PID_FILE = '/tmp/.bref/php-fpm.pid';


### PR DESCRIPTION
`@internal` let's us signal which classes are not covered by the BC promise. These classes are internal to Bref and can change at any time.

`final` let's us prevent users from extending a class, giving us more freedom to change them without breaking BC.

We are free to remove some limitations like these in the future of course (these are not final decisions), but it's safer to start with limitations and remove them.

Please comment if one of these changes might affect you. If you are a "classic" Bref user then it shouldn't.