### PR TITLE
Move the project to the Bref organization on GitHub and Packagist

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ layout: home
 
 [![Running PHP made simple. Bref provides tools and documentation to easily deploy and run serverless PHP applications. Learn more](docs/readme-screenshot.png)](https://bref.sh/)
 
-[![Build Status](https://travis-ci.com/mnapoli/bref.svg?branch=master)](https://travis-ci.com/mnapoli/bref)
-[![Latest Version](https://img.shields.io/github/release/mnapoli/bref.svg?style=flat-square)](https://packagist.org/packages/mnapoli/bref)
-[![PrettyCI Status](https://hc4rcprbe1.execute-api.eu-west-1.amazonaws.com/dev?name=mnapoli/bref)](https://prettyci.com/)
-[![Monthly Downloads](https://img.shields.io/packagist/dm/mnapoli/bref.svg)](https://packagist.org/packages/mnapoli/bref/stats)
+[![Build Status](https://travis-ci.com/brefphp/bref.svg?branch=master)](https://travis-ci.com/brefphp/bref)
+[![Latest Version](https://img.shields.io/github/release/bref/bref.svg?style=flat-square)](https://packagist.org/packages/bref/bref)
+[![PrettyCI Status](https://hc4rcprbe1.execute-api.eu-west-1.amazonaws.com/dev?name=brefphp/bref)](https://prettyci.com/)
+[![Monthly Downloads](https://img.shields.io/packagist/dm/bref/bref.svg)](https://packagist.org/packages/bref/bref/stats)
 
 Read more on [the website](https://bref.sh/).
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mnapoli/bref",
+    "name": "bref/bref",
     "license": "MIT",
     "type": "project",
     "description": "Bref is a framework to write and deploy serverless PHP applications on AWS Lambda.",

--- a/docs/community.md
+++ b/docs/community.md
@@ -4,7 +4,7 @@ currentMenu: community
 introduction: A collection of links to places where to discuss and learn about Bref.
 ---
 
-To report bugs you can head over to the [GitHub Bref repository](https://github.com/mnapoli/bref).
+To report bugs you can head over to the [GitHub Bref repository](https://github.com/brefphp/bref).
 
 You can also join the [Slack community](https://join.slack.com/t/brefworkspace/shared_invite/enQtNTcwMjU2NTcxNjAxLWRiZGUzZGJiZDNmZmM4NWUwMThhNjhlYmNiZTY2ZDEwMTBlOWY1NjAyOWQzODQxY2JkMjFmOGZjOWE0Y2YzZTg) to discuss Bref and exchange with the community.
 
@@ -12,7 +12,7 @@ On Twitter use [#BrefPHP](https://twitter.com/search?q=%23BrefPHP) to follow and
 
 ## Contributors
 
-The full list of contributors to Bref is [available here](https://github.com/mnapoli/bref/graphs/contributors).
+The full list of contributors to Bref is [available here](https://github.com/brefphp/bref/graphs/contributors).
 
 ## Newsletters
 

--- a/docs/first-steps.md
+++ b/docs/first-steps.md
@@ -19,7 +19,7 @@ Before getting started make sure you have [installed Bref and the required tools
 Starting in an empty directory, install Bref using Composer:
 
 ```
-composer require mnapoli/bref
+composer require bref/bref
 ```
 
 Then let's start by initializing the project by running:

--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -13,7 +13,7 @@ A demo application is available on GitHub at [github.com/mnapoli/bref-laravel-de
 Assuming your are in existing Laravel project, let's install Bref via Composer:
 
 ```
-composer require mnapoli/bref
+composer require bref/bref
 ```
 
 Then let's create a `template.yaml` configuration file (at the root of the project) optimized for Laravel:

--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -13,7 +13,7 @@ A demo application is available on GitHub at [github.com/mnapoli/bref-symfony-de
 Assuming your are in existing Symfony project, let's install Bref via Composer:
 
 ```
-composer require mnapoli/bref
+composer require bref/bref
 ```
 
 Then let's create a `template.yaml` configuration file (at the root of the project) optimized for Symfony:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,7 @@ Alternatively the region can be overridden on every SAM command by setting the `
 Install Bref in your project using [Composer](https://getcomposer.org/):
 
 ```
-composer require mnapoli/bref
+composer require bref/bref
 ```
 
 > To run the latest version of Bref you must have PHP 7.2 or greater! If you are using PHP 7.1 or less an older (outdated) version of Bref will be installed instead.

--- a/runtime/php/compiler.Dockerfile
+++ b/runtime/php/compiler.Dockerfile
@@ -12,7 +12,7 @@ FROM amazonlinux:2017.03
 LABEL authors="Bubba Hines <bubba@stechstudio.com>"
 LABEL vendor1="Signature Tech Studio, Inc."
 LABEL vendor2="bref"
-LABEL home="https://github.com/mnapoli/bref"
+LABEL home="https://github.com/brefphp/bref"
 
 
 # Working Directory

--- a/runtime/php/layers/fpm/php-fpm.conf
+++ b/runtime/php/layers/fpm/php-fpm.conf
@@ -19,5 +19,5 @@ catch_workers_output = yes
 ; Disabled for now until we switch to PHP 7.3
 ;decorate_workers_output = no
 ; Limit the number of core dump logs to 1 to avoid filling up the /tmp disk
-; See https://github.com/mnapoli/bref/issues/275
+; See https://github.com/brefphp/bref/issues/275
 rlimit_core = 1

--- a/runtime/php/layers/fpm/php.ini
+++ b/runtime/php/layers/fpm/php.ini
@@ -23,9 +23,9 @@ zend_extension=opcache.so
 ; starts up. G,P,C,E & S are abbreviations for the following respective super
 ; globals: GET, POST, COOKIE, ENV and SERVER.
 ; We explicitly populate all variables else ENV is not populated by default.
-; See https://github.com/mnapoli/bref/pull/291
+; See https://github.com/brefphp/bref/pull/291
 variables_order="EGPCS"
 
 ; The lambda environment is not compatible with fastcgi_finish_request
-; See https://github.com/mnapoli/bref/issues/214
+; See https://github.com/brefphp/bref/issues/214
 disable_functions=fastcgi_finish_request

--- a/runtime/php/layers/function/php.ini
+++ b/runtime/php/layers/function/php.ini
@@ -29,5 +29,5 @@ zend_extension=opcache.so
 ; starts up. G,P,C,E & S are abbreviations for the following respective super
 ; globals: GET, POST, COOKIE, ENV and SERVER.
 ; We explicitly populate all variables else ENV is not populated by default.
-; See https://github.com/mnapoli/bref/pull/291
+; See https://github.com/brefphp/bref/pull/291
 variables_order="EGPCS"

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -218,7 +218,7 @@ final class PhpFpm
             $request->setContentType($headers['content-type'][0]);
         }
         // Auto-add the Content-Length header if it wasn't provided
-        // See https://github.com/mnapoli/bref/issues/162
+        // See https://github.com/brefphp/bref/issues/162
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-length'])) {
             $headers['content-length'] = [strlen($requestBody)];
         }

--- a/tests/Runtime/PhpFpm/php-fpm.conf
+++ b/tests/Runtime/PhpFpm/php-fpm.conf
@@ -16,7 +16,7 @@ catch_workers_output = yes
 ; Disabled for now until we switch to PHP 7.3
 ;decorate_workers_output = no
 ; Limit the number of core dump logs to 1 to avoid filling up the /tmp disk
-; See https://github.com/mnapoli/bref/issues/275
+; See https://github.com/brefphp/bref/issues/275
 rlimit_core = 1
 
 ; Very short timeout to be able to test timeouts without having a very long test suite

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -300,7 +300,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
     }
 
     /**
-     * @see https://github.com/mnapoli/bref/issues/162
+     * @see https://github.com/brefphp/bref/issues/162
      *
      * @dataProvider provideHttpMethodsWithRequestBodySupport
      */
@@ -863,7 +863,7 @@ Year,Make,Model
     }
 
     /**
-     * @see https://github.com/mnapoli/bref/issues/316
+     * @see https://github.com/brefphp/bref/issues/316
      */
     public function test large response()
     {

--- a/website/template/default.twig
+++ b/website/template/default.twig
@@ -18,7 +18,7 @@
             <nav class="mt-2">
                 <h2 class="mb-8">
                     <a class="text-grey hover:text-grey-darker" href="/" title="Bref home page">Bref</a>
-                    <a class="float-right text-grey hover:text-grey-darker" title="Bref on GitHub" href="https://github.com/mnapoli/bref">
+                    <a class="float-right text-grey hover:text-grey-darker" title="Bref on GitHub" href="https://github.com/brefphp/bref">
                         <svg class="fill-current w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>GitHub</title><path d="M10 0a10 10 0 0 0-3.16 19.49c.5.1.68-.22.68-.48l-.01-1.7c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.11-1.47-1.11-1.47-.9-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.1-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.1.39-1.99 1.03-2.69a3.6 3.6 0 0 1 .1-2.64s.84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.3 2.75-1.02 2.75-1.02.55 1.37.2 2.4.1 2.64.64.7 1.03 1.6 1.03 2.69 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85l-.01 2.75c0 .26.18.58.69.48A10 10 0 0 0 10 0"></path></svg>
                     </a>
                 </h2>
@@ -40,7 +40,7 @@
             <div class="lg:max-w-700px">
                 {% block content %}
                     <article>
-                        <a href="https://github.com/mnapoli/bref/blob/master/{{ currentFile }}" title="Improve the documentation by editing this file online"
+                        <a href="https://github.com/brefphp/bref/blob/master/{{ currentFile }}" title="Improve the documentation by editing this file online"
                            class="hidden md:inline-block float-right text-sm hover:bg-grey-lightest text-grey-darkest py-2 px-4 border border-grey-light rounded">
                             Edit <span class="hidden lg:inline">on GitHub</span>
                         </a>

--- a/website/template/home.twig
+++ b/website/template/home.twig
@@ -14,7 +14,7 @@
 
             <div class="mt-16 md:flex justify-center">
                 <a class="block text-center px-10 py-4 border-2 border-grey-darkest rounded-lg bg-grey-darkest text-white hover:text-white hover:border-black hover:bg-black mb-4 md:mr-8" href="/docs/" title="Bref documentation for serverless PHP applications">Learn more</a>
-                <a class="block text-center px-10 py-4 border-2 border-grey-darkest rounded-lg bg-white text-grey-darkest hover:text-white hover:border-black hover:bg-black mb-4" href="https://github.com/mnapoli/bref" title="Bref on GitHub">GitHub</a>
+                <a class="block text-center px-10 py-4 border-2 border-grey-darkest rounded-lg bg-white text-grey-darkest hover:text-white hover:border-black hover:bg-black mb-4" href="https://github.com/brefphp/bref" title="Bref on GitHub">GitHub</a>
             </div>
 
             <div class="mt-20 md:flex justify-center">


### PR DESCRIPTION
Fixes #328

On GitHub the project will be moved to the https://github.com/brefphp organization. GitHub will redirect the old URL (https://github.com/mnapoli/bref) to the new one (https://github.com/brefphp/bref).

On Packagist the project will be renamed from `mnapoli/bref` to `bref/bref`. The old versions will continue to exist and be installable via `mnapoli/bref`. The old and new versions will be installable via `bref/bref`.

I plan on tagging this as 0.4.0 as well to avoid any confusion. There should be no BC break (but it will be documented in the release notes).